### PR TITLE
Do not override internal OAuthLib property

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -345,7 +345,6 @@ class OAuth2Validator(RequestValidator):
         try:
             rt = RefreshToken.objects.get(token=refresh_token)
             request.user = rt.user
-            request.refresh_token = rt
             return rt.application == client
 
         except RefreshToken.DoesNotExist:


### PR DESCRIPTION
The previous code broke OAuthLib when `rotate_refresh_token()` returned `False`. OAuthLib would attempt to serialize the `RefreshToken` object into JSON (it is supposed to be a string).

[This](https://github.com/idan/oauthlib/blob/96dc15143ef3baff66231711d33f4d5c6eb94f7b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py#L97-L98) is where the `refresh_token` gets replaced by oauth-toolkit, and [this](https://github.com/idan/oauthlib/blob/20d6640a7c8eadc4b5af15895c1358b868a02464/oauthlib/oauth2/rfc6749/tokens.py#L225) is where it breaks OAuthLib.