### PR TITLE
Allow custom uri schemes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Stéphane Raimbault
 Emanuele Palazzetti
 David Fischer
 Ash Christopher
+Rodney Richardson

--- a/oauth2_provider/__init__.py
+++ b/oauth2_provider/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 
 __author__ = "Massimiliano Pippi & Federico Frenguelli"
 

--- a/oauth2_provider/http.py
+++ b/oauth2_provider/http.py
@@ -1,0 +1,9 @@
+from django.http import HttpResponseRedirect
+
+from .settings import oauth2_settings
+
+
+class HttpResponseUriRedirect(HttpResponseRedirect):
+    def __init__(self, redirect_to, *args, **kwargs):
+        self.allowed_schemes = oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES
+        super(HttpResponseUriRedirect, self).__init__(redirect_to, *args, **kwargs)

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -41,6 +41,7 @@ DEFAULTS = {
     'ACCESS_TOKEN_EXPIRE_SECONDS': 36000,
     'APPLICATION_MODEL': getattr(settings, 'OAUTH2_PROVIDER_APPLICATION_MODEL', 'oauth2_provider.Application'),
     'REQUEST_APPROVAL_PROMPT': 'force',
+    'ALLOWED_REDIRECT_URI_SCHEMES': ['http', 'https'],
 
     # Special settings that will be evaluated at runtime
     '_SCOPES': [],
@@ -52,6 +53,7 @@ MANDATORY = (
     'CLIENT_SECRET_GENERATOR_CLASS',
     'OAUTH2_VALIDATOR_CLASS',
     'SCOPES',
+    'ALLOWED_REDIRECT_URI_SCHEMES',
 )
 
 # List of settings that may be in string import notation.

--- a/oauth2_provider/tests/test_authorization_code.py
+++ b/oauth2_provider/tests/test_authorization_code.py
@@ -32,9 +32,11 @@ class BaseTest(TestCaseUtils, TestCase):
         self.test_user = UserModel.objects.create_user("test_user", "test@user.com", "123456")
         self.dev_user = UserModel.objects.create_user("dev_user", "dev@user.com", "123456")
 
+        oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES = ['http', 'custom-scheme']
+        
         self.application = Application(
             name="Test Application",
-            redirect_uris="http://localhost http://example.com http://example.it",
+            redirect_uris="http://localhost http://example.com http://example.it custom-scheme://example.com",
             user=self.dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
@@ -88,6 +90,34 @@ class TestAuthorizationCodeView(BaseTest):
 
         form = response.context["form"]
         self.assertEqual(form['redirect_uri'].value(), "http://example.it")
+        self.assertEqual(form['state'].value(), "random_state_string")
+        self.assertEqual(form['scope'].value(), "read write")
+        self.assertEqual(form['client_id'].value(), self.application.client_id)
+
+    def test_pre_auth_valid_client_custom_redirect_uri_scheme(self):
+        """
+        Test response for a valid client_id with response_type: code
+        using a non-standard, but allowed, redirect_uri scheme.
+        """
+        self.client.login(username="test_user", password="123456")
+
+        query_string = urlencode({
+            'client_id': self.application.client_id,
+            'response_type': 'code',
+            'state': 'random_state_string',
+            'scope': 'read write',
+            'redirect_uri': 'custom-scheme://example.com',
+        })
+        url = "{url}?{qs}".format(url=reverse('oauth2_provider:authorize'), qs=query_string)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # check form is in context and form params are valid
+        self.assertIn("form", response.context)
+
+        form = response.context["form"]
+        self.assertEqual(form['redirect_uri'].value(), "custom-scheme://example.com")
         self.assertEqual(form['state'].value(), "random_state_string")
         self.assertEqual(form['scope'].value(), "read write")
         self.assertEqual(form['client_id'].value(), self.application.client_id)
@@ -306,6 +336,49 @@ class TestAuthorizationCodeView(BaseTest):
 
         response = self.client.post(reverse('oauth2_provider:authorize'), data=form_data)
         self.assertEqual(response.status_code, 400)
+
+    def test_code_post_auth_allow_custom_redirect_uri_scheme(self):
+        """
+        Test authorization code is given for an allowed request with response_type: code
+        using a non-standard, but allowed, redirect_uri scheme.
+        """
+        self.client.login(username="test_user", password="123456")
+
+        form_data = {
+            'client_id': self.application.client_id,
+            'state': 'random_state_string',
+            'scope': 'read write',
+            'redirect_uri': 'custom-scheme://example.com',
+            'response_type': 'code',
+            'allow': True,
+        }
+
+        response = self.client.post(reverse('oauth2_provider:authorize'), data=form_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('custom-scheme://example.com?', response['Location'])
+        self.assertIn('state=random_state_string', response['Location'])
+        self.assertIn('code=', response['Location'])
+
+    def test_code_post_auth_deny_custom_redirect_uri_scheme(self):
+        """
+        Test error when resource owner deny access
+        using a non-standard, but allowed, redirect_uri scheme.
+        """
+        self.client.login(username="test_user", password="123456")
+
+        form_data = {
+            'client_id': self.application.client_id,
+            'state': 'random_state_string',
+            'scope': 'read write',
+            'redirect_uri': 'custom-scheme://example.com',
+            'response_type': 'code',
+            'allow': False,
+        }
+
+        response = self.client.post(reverse('oauth2_provider:authorize'), data=form_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('custom-scheme://example.com?', response['Location'])
+        self.assertIn("error=access_denied", response['Location'])
 
 
 class TestAuthorizationCodeTokenView(BaseTest):

--- a/oauth2_provider/tests/test_validators.py
+++ b/oauth2_provider/tests/test_validators.py
@@ -3,17 +3,35 @@ from __future__ import unicode_literals
 from django.test import TestCase
 from django.core.validators import ValidationError
 
+from ..settings import oauth2_settings
 from ..validators import validate_uris
 
 
 class TestValidators(TestCase):
     def test_validate_good_uris(self):
-        good_urls = 'http://example.com/ http://example.it/?key=val http://example'
+        good_uris = 'http://example.com/ http://example.it/?key=val http://example'
         # Check ValidationError not thrown
-        validate_uris(good_urls)
+        validate_uris(good_uris)
+
+    def test_validate_custom_uri_scheme(self):
+        oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES = ['my-scheme', 'http']
+        good_uris = 'my-scheme://example.com http://example.com'
+        # Check ValidationError not thrown
+        validate_uris(good_uris)
+
+    def test_validate_whitespace_separators(self):
+        # Check that whitespace can be used as a separator
+        good_uris = 'http://example\r\nhttp://example\thttp://example'
+        # Check ValidationError not thrown
+        validate_uris(good_uris)
 
     def test_validate_bad_uris(self):
-        bad_url = 'http://example.com/#fragment'
-        self.assertRaises(ValidationError, validate_uris, bad_url)
-        bad_url = 'http:/example.com'
-        self.assertRaises(ValidationError, validate_uris, bad_url)
+        bad_uri = 'http://example.com/#fragment'
+        self.assertRaises(ValidationError, validate_uris, bad_uri)
+        bad_uri = 'http:/example.com'
+        self.assertRaises(ValidationError, validate_uris, bad_uri)
+        bad_uri = 'my-scheme://example.com'
+        self.assertRaises(ValidationError, validate_uris, bad_uri)
+        bad_uri = 'sdklfsjlfjljdflksjlkfjsdkl'
+        self.assertRaises(ValidationError, validate_uris, bad_uri)
+        


### PR DESCRIPTION
As per [#154](https://github.com/evonove/django-oauth-toolkit/issues/154).