### PR TITLE
Allowed RedirectURIs fixed

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -93,7 +93,10 @@ class AbstractApplication(models.Model):
 
         :param uri: Url to check
         """
-        return uri in self.redirect_uris.split()
+        for allowed_uri in self.redirect_uris.split():
+            if uri.startswith(allowed_uri):
+                return True
+        return False
 
     def clean(self):
         from django.core.exceptions import ValidationError
@@ -148,7 +151,7 @@ class Grant(models.Model):
         return timezone.now() >= self.expires
 
     def redirect_uri_allowed(self, uri):
-        return uri == self.redirect_uri
+        return uri.split('?')[0] == self.redirect_uri.split('?')[0]
 
     def __str__(self):
         return self.code


### PR DESCRIPTION
1. There is a problem with allowed redirect URIs check. Redirect URI must start with one of the allowed URIs, it does not have to be fully equal. It is generally accepted practice, for example Slack uses such approach when authorizes clients with OAuth2 protocol. 
2. The second problem is that redirect URIs can contain query strings after '?' symbol, some consumers could use query strings for some sort of reasons. It is better to compare paths without query strings.

I've stumbled on these when I was writing backend for django-social-auth which is used by Sentry.