### PR TITLE
Improving curl example

### DIFF
--- a/docs/rest-framework/getting_started.rst
+++ b/docs/rest-framework/getting_started.rst
@@ -126,7 +126,7 @@ At this point we're ready to request an access_token. Open your shell
 
 ::
 
-    curl -X POST -d "grant_type=password&username=<user_name>&password=<password>" http://<client_id>:<client_secret>@localhost:8000/o/token/
+    curl -X POST -d "grant_type=password&username=<user_name>&password=<password>" -u'<client_id>:<client_secret>' http://localhost:8000/o/token/
 
 The *user_name* and *password* are the credential on any user registered in your :term:`Authorization Server`, like any user created in Step 2.
 Response should be something like:


### PR DESCRIPTION
I've removed <client_id> and <client_secret> from the "url" because it could have symbols like "!" and "@" wich makes curl not work ok, so I've used the -u flag to pass the client_di and secret between quotes.