### PR TITLE
Fixed valunarabilities on Basic authentication. 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Stéphane Raimbault
 Emanuele Palazzetti
 David Fischer
 Ash Christopher
+Rodney Richardson

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Emanuele Palazzetti
 David Fischer
 Ash Christopher
 Rodney Richardson
+Hiroki Kiyohara

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -35,7 +35,7 @@ class OAuth2Validator(RequestValidator):
         if not auth:
             return None
 
-        auth_type, auth_string = auth.split(' ')
+        auth_type, auth_string = auth.split(' ', 1)
         if auth_type != "Basic":
             return None
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -36,7 +36,11 @@ class OAuth2Validator(RequestValidator):
         if not auth:
             return None
 
-        auth_type, auth_string = auth.split(' ', 1)
+        splitted = auth.split(' ', 1)
+        if len(splitted) != 2:
+            return None
+        auth_type, auth_string = splitted
+
         if auth_type != "Basic":
             return None
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import base64
+import binascii
 import logging
 from datetime import timedelta
 
@@ -56,7 +57,7 @@ class OAuth2Validator(RequestValidator):
 
         try:
             b64_decoded = base64.b64decode(auth_string)
-        except TypeError:
+        except (TypeError, binascii.Error):
             log.debug("Failed basic auth: %s can't be decoded as base64", auth_string)
             return False
 

--- a/oauth2_provider/tests/test_oauth2_validators.py
+++ b/oauth2_provider/tests/test_oauth2_validators.py
@@ -42,6 +42,8 @@ class TestOAuth2Validator(TestCase):
         self.assertIsNone(self.validator._extract_basic_auth(self.request))
         self.request.headers = {'HTTP_AUTHORIZATION': 'Dummy 123456'}
         self.assertIsNone(self.validator._extract_basic_auth(self.request))
+        self.request.headers = {'HTTP_AUTHORIZATION': 'Basic'}
+        self.assertIsNone(self.validator._extract_basic_auth(self.request))
         self.request.headers = {'HTTP_AUTHORIZATION': 'Basic 123456 789'}
         self.assertEqual(self.validator._extract_basic_auth(self.request), '123456 789')
 

--- a/oauth2_provider/tests/test_oauth2_validators.py
+++ b/oauth2_provider/tests/test_oauth2_validators.py
@@ -42,6 +42,8 @@ class TestOAuth2Validator(TestCase):
         self.assertIsNone(self.validator._extract_basic_auth(self.request))
         self.request.headers = {'HTTP_AUTHORIZATION': 'Dummy 123456'}
         self.assertIsNone(self.validator._extract_basic_auth(self.request))
+        self.request.headers = {'HTTP_AUTHORIZATION': 'Basic 123456 789'}
+        self.assertEqual(self.validator._extract_basic_auth(self.request), '123456 789')
 
     def test_authenticate_client_id(self):
         self.assertTrue(self.validator.authenticate_client_id('client_id', self.request))


### PR DESCRIPTION
django-oauth-toolkit 0.7.2 contains three valunarabilitis on Basic authentication process. 

* It will raise IndexError when authentication header contains more than two white spaces. 
* It will raise TypeError when auth_string can't be decoded as base64.
* It will raise UnicodeDecodeError when base64 decoded auth_string can't be decoded as unicode by specified encoding.
