### PR TITLE
Django 1.7 compatibility and SchemedHttpResponseRedirect

### DIFF
--- a/oauth2_provider/__init__.py
+++ b/oauth2_provider/__init__.py
@@ -3,3 +3,5 @@ __version__ = '0.7.2'
 __author__ = "Massimiliano Pippi & Federico Frenguelli"
 
 VERSION = __version__  # synonym
+
+default_app_config = 'oauth2_provider.apps.OAuth2ProviderConfig'

--- a/oauth2_provider/apps.py
+++ b/oauth2_provider/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class OAuth2ProviderConfig(AppConfig):
+    name = 'oauth2_provider'
+    verbose_name = "OAuth2 provider"

--- a/oauth2_provider/apps.py
+++ b/oauth2_provider/apps.py
@@ -6,18 +6,19 @@ class OAuth2ProviderConfig(AppConfig):
     verbose_name = "OAuth2 provider"
 
     def ready(self):
+        # Monkey-patch Meta.model and other root objects
         from .models import get_application_model
         Application = get_application_model()
 
-        # monkey-patch ApplicationOwnerIsUserMixin model
+        # monkey-patch views/application.ApplicationOwnerIsUserMixin model
         from .views.application import ApplicationOwnerIsUserMixin
         ApplicationOwnerIsUserMixin.model = Application
 
-        # monkey-patch RegistrationForm model
+        # monkey-patch forms.RegistrationForm model
         from .forms import RegistrationForm
         RegistrationForm.Meta.model = Application
 
-        # monkey-patch GRANT_TYPE_MAPPING
+        # monkey-patch oauth2_validators.Appliacation and GRANT_TYPE_MAPPING
         from . import oauth2_validators
         oauth2_validators.Application = Application
         oauth2_validators.GRANT_TYPE_MAPPING = {

--- a/oauth2_provider/apps.py
+++ b/oauth2_provider/apps.py
@@ -4,3 +4,25 @@ from django.apps import AppConfig
 class OAuth2ProviderConfig(AppConfig):
     name = 'oauth2_provider'
     verbose_name = "OAuth2 provider"
+
+    def ready(self):
+        from .models import get_application_model
+        Application = get_application_model()
+
+        # monkey-patch ApplicationOwnerIsUserMixin model
+        from .views.application import ApplicationOwnerIsUserMixin
+        ApplicationOwnerIsUserMixin.model = Application
+
+        # monkey-patch RegistrationForm model
+        from .forms import RegistrationForm
+        RegistrationForm.Meta.model = Application
+
+        # monkey-patch GRANT_TYPE_MAPPING
+        from . import oauth2_validators
+        oauth2_validators.GRANT_TYPE_MAPPING = {
+            'authorization_code': (Application.GRANT_AUTHORIZATION_CODE,),
+            'password': (Application.GRANT_PASSWORD,),
+            'client_credentials': (Application.GRANT_CLIENT_CREDENTIALS,),
+            'refresh_token': (Application.GRANT_AUTHORIZATION_CODE, Application.GRANT_PASSWORD,
+                              Application.GRANT_CLIENT_CREDENTIALS)
+        }

--- a/oauth2_provider/apps.py
+++ b/oauth2_provider/apps.py
@@ -19,6 +19,7 @@ class OAuth2ProviderConfig(AppConfig):
 
         # monkey-patch GRANT_TYPE_MAPPING
         from . import oauth2_validators
+        oauth2_validators.Application = Application
         oauth2_validators.GRANT_TYPE_MAPPING = {
             'authorization_code': (Application.GRANT_AUTHORIZATION_CODE,),
             'password': (Application.GRANT_PASSWORD,),

--- a/oauth2_provider/compat.py
+++ b/oauth2_provider/compat.py
@@ -26,6 +26,13 @@ else:
     AUTH_USER_MODEL = 'auth.User'
 
 try:
+    # Django's new application loading system
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    from django.db.models import get_model
+
+try:
     from django.contrib.auth import get_user_model
 except ImportError:
     from django.contrib.auth.models import User

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -1,7 +1,5 @@
 from django import forms
 
-# from .models import get_application_model
-
 
 class AllowForm(forms.Form):
     allow = forms.BooleanField(required=False)
@@ -24,5 +22,6 @@ class RegistrationForm(forms.ModelForm):
     TODO: add docstring
     """
     class Meta:
-        # model = get_application_model()
+        # FIXME: monkey-patched in apps.py
+        model = None
         fields = ('name', 'client_id', 'client_secret', 'client_type', 'authorization_grant_type', 'redirect_uris')

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from .models import get_application_model
+# from .models import get_application_model
 
 
 class AllowForm(forms.Form):
@@ -24,5 +24,5 @@ class RegistrationForm(forms.ModelForm):
     TODO: add docstring
     """
     class Meta:
-        model = get_application_model()
+        # model = get_application_model()
         fields = ('name', 'client_id', 'client_secret', 'client_type', 'authorization_grant_type', 'redirect_uris')

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -12,6 +12,7 @@ except ImportError:
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.six.moves.urllib.parse import urlparse
 
 from .settings import oauth2_settings
 from .compat import AUTH_USER_MODEL
@@ -95,6 +96,18 @@ class AbstractApplication(models.Model):
         :param uri: Url to check
         """
         return uri in self.redirect_uris.split()
+
+    @property
+    def redirect_uri_schemes(self):
+        """
+        Returns the set of schemes used by the :attr:`redirect_uris`.
+        """
+        schemes = set()
+        for uri in self.redirect_uris.split():
+            parsed = urlparse(uri)
+            if parsed.scheme:
+                schemes.add(parsed.scheme)
+        return schemes
 
     def clean(self):
         from django.core.exceptions import ValidationError

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -239,7 +239,17 @@ def get_application_model():
     except ValueError:
         e = "APPLICATION_MODEL must be of the form 'app_label.model_name'"
         raise ImproperlyConfigured(e)
-    app_model = get_model(app_label, model_name)
+
+    try:
+        # Django >=1.7
+        from django.apps import apps
+        try:
+            app_model = apps.get_model(app_label, model_name)
+        except LookupError:
+            app_model = None
+    except ImportError:
+        app_model = get_model(app_label, model_name)
+
     if app_model is None:
         e = "APPLICATION_MODEL refers to model {0} that has not been installed"
         raise ImproperlyConfigured(e.format(oauth2_settings.APPLICATION_MODEL))

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -3,19 +3,13 @@ from __future__ import unicode_literals
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
-try:
-    # Django's new application loading system
-    from django.apps import apps
-    get_model = apps.get_model
-except ImportError:
-    from django.db.models import get_model
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.six.moves.urllib.parse import urlparse
 
 from .settings import oauth2_settings
-from .compat import AUTH_USER_MODEL
+from .compat import AUTH_USER_MODEL, get_model
 from .generators import generate_client_secret, generate_client_id
 from .validators import validate_uris
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -10,20 +10,14 @@ from django.core.exceptions import ObjectDoesNotExist
 from oauthlib.oauth2 import RequestValidator
 
 from .compat import unquote_plus
-from .models import Grant, AccessToken, RefreshToken, get_application_model
+from .models import Grant, AccessToken, RefreshToken
 from .settings import oauth2_settings
 
-# Application = get_application_model()
+Application = None
 
 log = logging.getLogger('oauth2_provider')
 
-# GRANT_TYPE_MAPPING = {
-#     'authorization_code': (Application.GRANT_AUTHORIZATION_CODE,),
-#     'password': (Application.GRANT_PASSWORD,),
-#     'client_credentials': (Application.GRANT_CLIENT_CREDENTIALS,),
-#     'refresh_token': (Application.GRANT_AUTHORIZATION_CODE, Application.GRANT_PASSWORD,
-#                       Application.GRANT_CLIENT_CREDENTIALS)
-# }
+GRANT_TYPE_MAPPING = {}
 
 
 class OAuth2Validator(RequestValidator):

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -13,17 +13,17 @@ from .compat import unquote_plus
 from .models import Grant, AccessToken, RefreshToken, get_application_model
 from .settings import oauth2_settings
 
-Application = get_application_model()
+# Application = get_application_model()
 
 log = logging.getLogger('oauth2_provider')
 
-GRANT_TYPE_MAPPING = {
-    'authorization_code': (Application.GRANT_AUTHORIZATION_CODE,),
-    'password': (Application.GRANT_PASSWORD,),
-    'client_credentials': (Application.GRANT_CLIENT_CREDENTIALS,),
-    'refresh_token': (Application.GRANT_AUTHORIZATION_CODE, Application.GRANT_PASSWORD,
-                      Application.GRANT_CLIENT_CREDENTIALS)
-}
+# GRANT_TYPE_MAPPING = {
+#     'authorization_code': (Application.GRANT_AUTHORIZATION_CODE,),
+#     'password': (Application.GRANT_PASSWORD,),
+#     'client_credentials': (Application.GRANT_CLIENT_CREDENTIALS,),
+#     'refresh_token': (Application.GRANT_AUTHORIZATION_CODE, Application.GRANT_PASSWORD,
+#                       Application.GRANT_CLIENT_CREDENTIALS)
+# }
 
 
 class OAuth2Validator(RequestValidator):

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -13,11 +13,12 @@ from .compat import unquote_plus
 from .models import Grant, AccessToken, RefreshToken
 from .settings import oauth2_settings
 
+# FIXME: monkey-patched in apps.py
 Application = None
+# FIXME: monkey-patched in apps.py
+GRANT_TYPE_MAPPING = {}
 
 log = logging.getLogger('oauth2_provider')
-
-GRANT_TYPE_MAPPING = {}
 
 
 class OAuth2Validator(RequestValidator):

--- a/oauth2_provider/views/application.py
+++ b/oauth2_provider/views/application.py
@@ -4,14 +4,14 @@ from django.views.generic import CreateView, DetailView, DeleteView, ListView, U
 from braces.views import LoginRequiredMixin
 
 from ..forms import RegistrationForm
-from ..models import get_application_model
 
 
 class ApplicationOwnerIsUserMixin(LoginRequiredMixin):
     """
     This mixin is used to provide an Application queryset filtered by the current request.user.
     """
-    # model = get_application_model()
+    # FIXME: monkey-patched in apps.py
+    model = None
     fields = '__all__'
 
     def get_queryset(self):

--- a/oauth2_provider/views/application.py
+++ b/oauth2_provider/views/application.py
@@ -11,7 +11,7 @@ class ApplicationOwnerIsUserMixin(LoginRequiredMixin):
     """
     This mixin is used to provide an Application queryset filtered by the current request.user.
     """
-    model = get_application_model()
+    # model = get_application_model()
     fields = '__all__'
 
     def get_queryset(self):

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -101,9 +101,9 @@ class AuthorizationView(BaseAuthorizationView, FormView):
             allow = form.cleaned_data.get('allow')
             uri, headers, body, status = self.create_authorization_response(
                 request=self.request, scopes=scopes, credentials=credentials, allow=allow)
-            self.success_url = uri
-            log.debug("Success url for the request: {0}".format(self.success_url))
-            return super(AuthorizationView, self).form_valid(form)
+            log.debug("Redirect uri for the request: {0}".format(uri))
+            application = get_application_model().objects.get(client_id=credentials['client_id'])  # TODO: cache it!
+            return SchemedHttpResponseRedirect(uri, allowed_schemes=application.redirect_uri_schemes)
 
         except OAuthToolkitError as error:
             return self.error_response(error)

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -16,8 +16,6 @@ from ..forms import AllowForm
 from ..models import get_application_model
 from .mixins import OAuthLibMixin
 
-Application = get_application_model()
-
 log = logging.getLogger('oauth2_provider')
 
 
@@ -115,7 +113,7 @@ class AuthorizationView(BaseAuthorizationView, FormView):
             kwargs['scopes_descriptions'] = [oauth2_settings.SCOPES[scope] for scope in scopes]
             kwargs['scopes'] = scopes
             # at this point we know an Application instance with such client_id exists in the database
-            application = Application.objects.get(client_id=credentials['client_id'])  # TODO: cache it!
+            application = get_application_model().objects.get(client_id=credentials['client_id'])  # TODO: cache it!
             kwargs['application'] = application
             kwargs.update(credentials)
             self.oauth2_data = kwargs

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -15,7 +15,7 @@ from ..exceptions import OAuthToolkitError
 from ..forms import AllowForm
 from ..models import get_application_model
 from .mixins import OAuthLibMixin
-from .util import CustomSchemesHttpResponseRedirect
+from .util import SchemedHttpResponseRedirect
 
 log = logging.getLogger('oauth2_provider')
 
@@ -131,7 +131,7 @@ class AuthorizationView(BaseAuthorizationView, FormView):
                     request=self.request, scopes=" ".join(scopes),
                     credentials=credentials, allow=True)
                 redirect_schemes = application.redirect_uri_schemes
-                return CustomSchemesHttpResponseRedirect(uri, allowed_schemes=redirect_schemes)
+                return SchemedHttpResponseRedirect(uri, allowed_schemes=redirect_schemes)
 
             # If skip_authorization field is True, skip the authorization screen even
             # if this is the first use of the application and there was no previous authorization.

--- a/oauth2_provider/views/util.py
+++ b/oauth2_provider/views/util.py
@@ -13,7 +13,7 @@ class SchemedHttpResponseRedirectBase(HttpResponseRedirectBase):
             self.allowed_schemes = kwargs.pop('allowed_schemes')
         except KeyError:
             pass
-        super(HttpResponseRedirectBase, self).__init__(redirect_to, *args, **kwargs)
+        super(SchemedHttpResponseRedirectBase, self).__init__(redirect_to, *args, **kwargs)
 
 
 class SchemedHttpResponseRedirect(SchemedHttpResponseRedirectBase):

--- a/oauth2_provider/views/util.py
+++ b/oauth2_provider/views/util.py
@@ -13,7 +13,7 @@ class SchemedHttpResponseRedirectBase(HttpResponseRedirectBase):
             self.allowed_schemes = kwargs.pop('allowed_schemes')
         except KeyError:
             pass
-        super(HttpResponseRedirectBase, self).__init__(*args, **kwargs)
+        super(HttpResponseRedirectBase, self).__init__(redirect_to, *args, **kwargs)
 
 
 class SchemedHttpResponseRedirect(SchemedHttpResponseRedirectBase):

--- a/oauth2_provider/views/util.py
+++ b/oauth2_provider/views/util.py
@@ -1,0 +1,22 @@
+from django.http import HttpResponseRedirect
+from django.core.exceptions import DisallowedRedirect
+from django.utils.encoding import force_text
+from django.utils.six.moves.urllib.parse import urlparse
+
+
+class CustomSchemesHttpResponseRedirect(HttpResponseRedirect):
+    """
+    HttpResponseRedirect subclass that accepts an `allowed_schemes`
+    positional argument to overwrite the default set of schemes.
+    Warning: if `allowed_schemes` is empty, all schemes are allowed.
+    """
+    def __init__(self, redirect_to, *args, **kwargs):
+        parsed = urlparse(force_text(redirect_to))
+        try:
+            self.allowed_schemes = kwargs.pop('allowed_schemes')
+        except KeyError:
+            pass
+        if self.allowed_schemes and parsed.scheme and parsed.scheme not in self.allowed_schemes:
+            raise DisallowedRedirect("Unsafe redirect to URL with protocol '%s'" % parsed.scheme)
+        super(HttpResponseRedirect, self).__init__(*args, **kwargs)
+        self['Location'] = iri_to_uri(redirect_to)

--- a/oauth2_provider/views/util.py
+++ b/oauth2_provider/views/util.py
@@ -1,22 +1,24 @@
-from django.http import HttpResponseRedirect
-from django.core.exceptions import DisallowedRedirect
-from django.utils.encoding import force_text
-from django.utils.six.moves.urllib.parse import urlparse
+from django.http import HttpResponseRedirectBase
 
 
-class CustomSchemesHttpResponseRedirect(HttpResponseRedirect):
+class SchemedHttpResponseRedirectBase(HttpResponseRedirectBase):
     """
-    HttpResponseRedirect subclass that accepts an `allowed_schemes`
+    HttpResponseRedirectBase-like class that accepts an `allowed_schemes`
     positional argument to overwrite the default set of schemes.
-    Warning: if `allowed_schemes` is empty, all schemes are allowed.
+    Warning: if `allowed_schemes` is empty, no scheme is allowed.
     """
+
     def __init__(self, redirect_to, *args, **kwargs):
-        parsed = urlparse(force_text(redirect_to))
         try:
             self.allowed_schemes = kwargs.pop('allowed_schemes')
         except KeyError:
             pass
-        if self.allowed_schemes and parsed.scheme and parsed.scheme not in self.allowed_schemes:
-            raise DisallowedRedirect("Unsafe redirect to URL with protocol '%s'" % parsed.scheme)
-        super(HttpResponseRedirect, self).__init__(*args, **kwargs)
-        self['Location'] = iri_to_uri(redirect_to)
+        super(HttpResponseRedirectBase, self).__init__(*args, **kwargs)
+
+
+class SchemedHttpResponseRedirect(SchemedHttpResponseRedirectBase):
+    status_code = 302
+
+
+class SchemedHttpResponsePermanentRedirect(SchemedHttpResponseRedirectBase):
+    status_code = 301

--- a/oauth2_provider/views/util.py
+++ b/oauth2_provider/views/util.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseRedirectBase
+from django.http.response import HttpResponseRedirectBase
 
 
 class SchemedHttpResponseRedirectBase(HttpResponseRedirectBase):


### PR DESCRIPTION
This PR fixes two things:

- With Django 1.7 it becomes impossible to have root-level functions that return a model class, as they're not yet loaded. Thus, the code below will fail. As a temporary workaround, I used monkey-patching within the application registry to make it work. This is quite hacky but I don't see any other way. See: #151 
```python
class MyForm(ModelForm):
  class Meta:
    model = some_func()
```
- HttpResponseRedirect has a very restrictive list of allowed schemes (http, https, ftp) and fails with HTTP 400 for everything else. This prevents mobile (eg. Android) OAuth applications to use custom handlers eg. `my-app-callback://oauth/`. This PR adds a `SchemedHttpResponseRedirect` that allows all the schemes extracted from `redirect_uris`. As such, it remains safe.

The code has been live-tested but there are no unit tests yet.

Feel free to make comments I you want me to change things.