### PR TITLE
Allow arbitrary schemes within HttpResponseRedirect()

### DIFF
--- a/oauth2_provider/views/http.py
+++ b/oauth2_provider/views/http.py
@@ -1,0 +1,23 @@
+from django.http import HttpResponse
+from django.utils.encoding import iri_to_uri
+
+
+class UnsafeHttpResponseRedirectBase(HttpResponse):
+    """
+    HttpResponseRedirectBase-like class that does not check the URI scheme.
+    You should validate user-controlled URIs before redirecting to them through
+    this class.
+    """
+    def __init__(self, redirect_to, *args, **kwargs):
+        super(UnsafeHttpResponseRedirectBase, self).__init__(*args, **kwargs)
+        self['Location'] = iri_to_uri(redirect_to)
+
+    url = property(lambda self: self['Location'])
+
+
+class UnsafeHttpResponseRedirect(UnsafeHttpResponseRedirectBase):
+    status_code = 302
+
+
+class UnsafeHttpResponsePermanentRedirect(UnsafeHttpResponseRedirectBase):
+    status_code = 301


### PR DESCRIPTION
`redirect_uri` is supposed to handle arbitrary schemes as per the RFC; this is especially useful for mobile app handlers eg. `mobile-app://my/callback?code=...`.

To this end, this PR implements `UnsafeHttpResponseRedirect` in `oauth2_provider/views/http.py` that does the same thing as `HttpResponseRedirect` except it does not check the scheme, as it is already done in the various validators.
It's a shame there is no base class in `django.http` to do the Location header stuff without the check, but anyway.

A test has been added to check this bugfix.

See #154 and #155 for discussions regarding the validation of the `redirect_uri` field iself.