### PR TITLE
use all fields instead of a hard coded list, so that extended models don't require extending the form

### DIFF
--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -25,4 +25,4 @@ class RegistrationForm(forms.ModelForm):
     """
     class Meta:
         model = get_application_model()
-        fields = ('name', 'client_id', 'client_secret', 'client_type', 'authorization_grant_type', 'redirect_uris')
+        fields = '__all__'


### PR DESCRIPTION
I'm not sure why the fields are hard-coded here, but I suggest using \_\_all\_\_. This way, end users don't necessarily have to extend/override RegistrationForm when using their own extension of AbstractApplication

fixes #208 