### PR TITLE
Pass str/bytes instead of unicode/str to urllib.quote

### DIFF
--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -26,7 +26,7 @@ class OAuthLibCore(object):
         parsed = list(urlparse(request.get_full_path()))
         unsafe = set(c for c in parsed[4]).difference(urlencoded)
         for c in unsafe:
-            parsed[4] = parsed[4].replace(c, quote(c, safe=''))
+            parsed[4] = parsed[4].replace(c, quote(c, safe=b''))
 
         return urlunparse(parsed)
 


### PR DESCRIPTION
On Python 2, passing unicode as the second argument to urllib.quote is a very bad idea - http://bugs.python.org/issue23885

On Python 3, both b'' and '' are fine.