### PR TITLE
Fixed #230 authentication does not pass in request

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -325,7 +325,7 @@ class OAuth2Validator(RequestValidator):
         """
         Check username and password correspond to a valid and active User
         """
-        u = authenticate(username=username, password=password)
+        u = authenticate(username=username, password=password, client=client, request=request)
         if u is not None and u.is_active:
             request.user = u
             return True


### PR DESCRIPTION
django-oauth-toolkit does not passing client or request to Django's ``authenticate``.  See issue: https://github.com/evonove/django-oauth-toolkit/issues/230