### PR TITLE
oauthlib_backend_class is now pluggable through Django settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,12 @@ Roadmap / Todo list (help wanted)
 Changelog
 ---------
 
+master branch
+~~~~~~~~~~~~~
+
+* ``oauthlib_backend_class`` is now pluggable through Django settings
+* #127: ``application/json`` Content-Type is now supported using ``JSONOAuthLibCore``
+
 0.8.0 [2015-03-27]
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+master branch
+-------------
+
+* ``oauthlib_backend_class`` is now pluggable through Django settings
+* #127: ``application/json`` Content-Type is now supported using ``JSONOAuthLibCore``
+
 0.8.0 [2015-03-27]
 ------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -64,6 +64,11 @@ OAUTH2_VALIDATOR_CLASS
 The import string of the ``oauthlib.oauth2.RequestValidator`` subclass that
 validates every step of the OAuth2 process.
 
+OAUTH2_BACKEND_CLASS
+~~~~~~~~~~~~~~~~~~~~
+The import string for the ``oauthlib_backend_class`` used in the ``OAuthLibMixin``,
+to get a ``Server`` instance.
+
 SCOPES
 ~~~~~~
 A dictionnary mapping each scope name to its human description.

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import json
+
 from oauthlib import oauth2
 from oauthlib.common import urlencode, urlencoded, quote
 
@@ -152,6 +154,24 @@ class OAuthLibCore(object):
 
         valid, r = self.server.verify_request(uri, http_method, body, headers, scopes=scopes)
         return valid, r
+
+
+class JSONOAuthLibCore(OAuthLibCore):
+    """
+    Extends the default OAuthLibCore to parse correctly requests with application/json Content-Type
+    """
+    def _extract_body(self, request):
+        """
+        Extracts the JSON body from the Django request object
+        :param request: The current django.http.HttpRequest object
+        :return: provided POST parameters "urlencodable"
+        """
+        try:
+            body = json.loads(request.body.decode('utf-8')).items()
+        except ValueError:
+            body = ""
+
+        return body
 
 
 def get_oauthlib_core():

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -32,7 +32,18 @@ class OAuthLibCore(object):
 
         return urlunparse(parsed)
 
-    def _extract_headers(self, request):
+    def _extract_params(self, request):
+        """
+        Extract parameters from the Django request object. Such parameters will then be passed to
+        OAuthLib to build its own Request object. The body should be encoded using OAuthLib urlencoded
+        """
+        uri = self._get_escaped_full_path(request)
+        http_method = request.method
+        headers = self.extract_headers(request)
+        body = urlencode(self.extract_body(request))
+        return uri, http_method, body, headers
+
+    def extract_headers(self, request):
         """
         Extracts headers from the Django request object
         :param request: The current django.http.HttpRequest object
@@ -48,24 +59,13 @@ class OAuthLibCore(object):
 
         return headers
 
-    def _extract_body(self, request):
+    def extract_body(self, request):
         """
         Extracts the POST body from the Django request object
         :param request: The current django.http.HttpRequest object
         :return: provided POST parameters
         """
         return request.POST.items()
-
-    def _extract_params(self, request):
-        """
-        Extract parameters from the Django request object. Such parameters will then be passed to
-        OAuthLib to build its own Request object. The body should be encoded using OAuthLib urlencoded
-        """
-        uri = self._get_escaped_full_path(request)
-        http_method = request.method
-        headers = self._extract_headers(request)
-        body = urlencode(self._extract_body(request))
-        return uri, http_method, body, headers
 
     def validate_authorization_request(self, request):
         """
@@ -160,7 +160,7 @@ class JSONOAuthLibCore(OAuthLibCore):
     """
     Extends the default OAuthLibCore to parse correctly requests with application/json Content-Type
     """
-    def _extract_body(self, request):
+    def extract_body(self, request):
         """
         Extracts the JSON body from the Django request object
         :param request: The current django.http.HttpRequest object

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -144,4 +144,4 @@ def get_oauthlib_core():
     from oauthlib.oauth2 import Server
 
     server = Server(oauth2_settings.OAUTH2_VALIDATOR_CLASS())
-    return OAuthLibCore(server)
+    return oauth2_settings.OAUTH2_BACKEND_CLASS(server)

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -34,6 +34,7 @@ DEFAULTS = {
     'CLIENT_SECRET_GENERATOR_CLASS': 'oauth2_provider.generators.ClientSecretGenerator',
     'CLIENT_SECRET_GENERATOR_LENGTH': 128,
     'OAUTH2_VALIDATOR_CLASS': 'oauth2_provider.oauth2_validators.OAuth2Validator',
+    'OAUTH2_BACKEND_CLASS': 'oauth2_provider.oauth2_backends.OAuthLibCore',
     'SCOPES': {"read": "Reading scope", "write": "Writing scope"},
     'READ_SCOPE': 'read',
     'WRITE_SCOPE': 'write',
@@ -52,6 +53,7 @@ MANDATORY = (
     'CLIENT_ID_GENERATOR_CLASS',
     'CLIENT_SECRET_GENERATOR_CLASS',
     'OAUTH2_VALIDATOR_CLASS',
+    'OAUTH2_BACKEND_CLASS',
     'SCOPES',
     'ALLOWED_REDIRECT_URI_SCHEMES',
 )
@@ -61,6 +63,7 @@ IMPORT_STRINGS = (
     'CLIENT_ID_GENERATOR_CLASS',
     'CLIENT_SECRET_GENERATOR_CLASS',
     'OAUTH2_VALIDATOR_CLASS',
+    'OAUTH2_BACKEND_CLASS',
 )
 
 

--- a/oauth2_provider/tests/test_client_credential.py
+++ b/oauth2_provider/tests/test_client_credential.py
@@ -14,6 +14,7 @@ from django.views.generic import View
 from oauthlib.oauth2 import BackendApplicationServer
 
 from ..models import get_application_model, AccessToken
+from ..oauth2_backends import OAuthLibCore
 from ..oauth2_validators import OAuth2Validator
 from ..settings import oauth2_settings
 from ..views import ProtectedResourceView
@@ -114,6 +115,7 @@ class TestExtendedRequest(BaseTest):
         class TestView(OAuthLibMixin, View):
             server_class = BackendApplicationServer
             validator_class = OAuth2Validator
+            oauthlib_backend_class = OAuthLibCore
 
             def get_scopes(self):
                 return ['read', 'write']

--- a/oauth2_provider/tests/test_mixins.py
+++ b/oauth2_provider/tests/test_mixins.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse
 from oauthlib.oauth2 import Server
 
 from ..views.mixins import OAuthLibMixin, ScopedResourceMixin, ProtectedResourceMixin
+from ..oauth2_backends import OAuthLibCore
 from ..oauth2_validators import OAuth2Validator
 
 
@@ -18,9 +19,19 @@ class BaseTest(TestCase):
 
 
 class TestOAuthLibMixin(BaseTest):
+    def test_missing_oauthlib_backend_class(self):
+        class TestView(OAuthLibMixin, View):
+            server_class = Server
+            validator_class = OAuth2Validator
+
+        test_view = TestView()
+
+        self.assertRaises(ImproperlyConfigured, test_view.get_oauthlib_backend_class)
+
     def test_missing_server_class(self):
         class TestView(OAuthLibMixin, View):
             validator_class = OAuth2Validator
+            oauthlib_backend_class = OAuthLibCore
 
         test_view = TestView()
 
@@ -29,6 +40,7 @@ class TestOAuthLibMixin(BaseTest):
     def test_missing_validator_class(self):
         class TestView(OAuthLibMixin, View):
             server_class = Server
+            oauthlib_backend_class = OAuthLibCore
 
         test_view = TestView()
 
@@ -38,6 +50,7 @@ class TestOAuthLibMixin(BaseTest):
         class TestView(OAuthLibMixin, View):
             server_class = Server
             validator_class = OAuth2Validator
+            oauthlib_backend_class = OAuthLibCore
 
         request = self.request_factory.get("/fake-req")
         request.user = "fake"

--- a/oauth2_provider/tests/test_mixins.py
+++ b/oauth2_provider/tests/test_mixins.py
@@ -52,13 +52,13 @@ class TestOAuthLibMixin(BaseTest):
         class TestView(OAuthLibMixin, View):
             server_class = Server
             validator_class = OAuth2Validator
-            oauthlib_core_class = AnotherOauthLibBackend
+            oauthlib_backend_class = AnotherOauthLibBackend
 
         request = self.request_factory.get("/fake-req")
         request.user = "fake"
         test_view = TestView()
 
-        self.assertEqual(test_view.get_oauthlib_core_class(),
+        self.assertEqual(test_view.get_oauthlib_backend_class(),
                          AnotherOauthLibBackend)
 
 

--- a/oauth2_provider/tests/test_oauth2_backends.py
+++ b/oauth2_provider/tests/test_oauth2_backends.py
@@ -1,7 +1,36 @@
 from django.test import TestCase, RequestFactory
-
+from django.test.utils import override_settings
 
 from ..backends import get_oauthlib_core
+
+
+@override_settings(OAUTH2_BACKEND_CLASS='oauth2_provider.oauth2_backends.OAuthLibCore')
+class TestOAuthLibCoreBackend(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.oauthlib_core = get_oauthlib_core()
+
+    def test_form_urlencoded_extract_params(self):
+        payload = "grant_type=password&username=john&password=123456"
+        request = self.factory.post("/o/token/", payload, content_type="application/x-www-form-urlencoded")
+
+        uri, http_method, body, headers = self.oauthlib_core._extract_params(request)
+        self.assertIn("grant_type=password", body)
+        self.assertIn("username=john", body)
+        self.assertIn("password=123456", body)
+
+    def test_application_json_extract_params(self):
+        payload = json.dumps({
+            "grant_type": "password",
+            "username": "john",
+            "password": "123456",
+        })
+        request = self.factory.post("/o/token/", payload, content_type="application/json")
+
+        uri, http_method, body, headers = self.oauthlib_core._extract_params(request)
+        self.assertNotIn("grant_type=password", body)
+        self.assertNotIn("username=john", body)
+        self.assertNotIn("password=123456", body)
 
 
 class TestOAuthLibCore(TestCase):

--- a/oauth2_provider/tests/test_oauth2_backends.py
+++ b/oauth2_provider/tests/test_oauth2_backends.py
@@ -1,14 +1,15 @@
+import json
+
 from django.test import TestCase, RequestFactory
-from django.test.utils import override_settings
 
 from ..backends import get_oauthlib_core
+from ..oauth2_backends import OAuthLibCore, JSONOAuthLibCore
 
 
-@override_settings(OAUTH2_BACKEND_CLASS='oauth2_provider.oauth2_backends.OAuthLibCore')
 class TestOAuthLibCoreBackend(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
-        self.oauthlib_core = get_oauthlib_core()
+        self.oauthlib_core = OAuthLibCore()
 
     def test_form_urlencoded_extract_params(self):
         payload = "grant_type=password&username=john&password=123456"
@@ -31,6 +32,25 @@ class TestOAuthLibCoreBackend(TestCase):
         self.assertNotIn("grant_type=password", body)
         self.assertNotIn("username=john", body)
         self.assertNotIn("password=123456", body)
+
+
+class TestJSONOAuthLibCoreBackend(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.oauthlib_core = JSONOAuthLibCore()
+
+    def test_application_json_extract_params(self):
+        payload = json.dumps({
+            "grant_type": "password",
+            "username": "john",
+            "password": "123456",
+        })
+        request = self.factory.post("/o/token/", payload, content_type="application/json")
+
+        uri, http_method, body, headers = self.oauthlib_core._extract_params(request)
+        self.assertIn("grant_type=password", body)
+        self.assertIn("username=john", body)
+        self.assertIn("password=123456", body)
 
 
 class TestOAuthLibCore(TestCase):

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -73,6 +73,7 @@ class AuthorizationView(BaseAuthorizationView, FormView):
 
     server_class = Server
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
+    oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 
     skip_authorization_completely = False
 
@@ -164,6 +165,7 @@ class TokenView(CsrfExemptMixin, OAuthLibMixin, View):
     """
     server_class = Server
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
+    oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 
     @method_decorator(sensitive_post_parameters('password'))
     def post(self, request, *args, **kwargs):
@@ -181,6 +183,7 @@ class RevokeTokenView(CsrfExemptMixin, OAuthLibMixin, View):
     """
     server_class = Server
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
+    oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 
     def post(self, request, *args, **kwargs):
         url, headers, body, status = self.create_revocation_response(request)

--- a/oauth2_provider/views/generic.py
+++ b/oauth2_provider/views/generic.py
@@ -12,6 +12,7 @@ class ProtectedResourceView(ProtectedResourceMixin, View):
     """
     server_class = Server
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
+    oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 
 
 class ScopedProtectedResourceView(ScopedResourceMixin, ProtectedResourceView):

--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -25,7 +25,7 @@ class OAuthLibMixin(object):
 
       * server_class
       * validator_class
-      * oauthlib_core_class  # TODO rename it as oauthlib_backend_class
+      * oauthlib_backend_class
 
     """
     server_class = None
@@ -56,16 +56,14 @@ class OAuthLibMixin(object):
             return cls.validator_class
 
     @classmethod
-    def get_oauthlib_core_class(cls):
+    def get_oauthlib_backend_class(cls):
         """
         Return the OAuthLibCore implementation class to use, silently
         defaults to OAuthLibCore class from oauth2_provider package
-
-        # TODO rename this as get_oauthlib_backend_class
         """
-        if not hasattr(cls, 'oauthlib_core_class'):
+        if not hasattr(cls, 'oauthlib_backend_class'):
             return OAuthLibCore
-        return cls.oauthlib_core_class
+        return cls.oauthlib_backend_class
 
     @classmethod
     def get_server(cls):
@@ -84,7 +82,7 @@ class OAuthLibMixin(object):
         """
         if not hasattr(cls, '_oauthlib_core'):
             server = cls.get_server()
-            core_class = cls.get_oauthlib_core_class()
+            core_class = cls.get_oauthlib_backend_class()
             cls._oauthlib_core = core_class(server)
         return cls._oauthlib_core
 

--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -5,7 +5,6 @@ import logging
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseForbidden
 
-from ..oauth2_backends import OAuthLibCore
 from ..exceptions import FatalClientError
 from ..settings import oauth2_settings
 
@@ -30,6 +29,7 @@ class OAuthLibMixin(object):
     """
     server_class = None
     validator_class = None
+    oauthlib_backend_class = None
 
     @classmethod
     def get_server_class(cls):
@@ -58,12 +58,14 @@ class OAuthLibMixin(object):
     @classmethod
     def get_oauthlib_backend_class(cls):
         """
-        Return the OAuthLibCore implementation class to use, silently
-        defaults to OAuthLibCore class from oauth2_provider package
+        Return the OAuthLibCore implementation class to use
         """
-        if not hasattr(cls, 'oauthlib_backend_class'):
-            return OAuthLibCore
-        return cls.oauthlib_backend_class
+        if cls.oauthlib_backend_class is None:
+            raise ImproperlyConfigured(
+                "OAuthLibMixin requires either a definition of 'oauthlib_backend_class'"
+                " or an implementation of 'get_oauthlib_backend_class()'")
+        else:
+            return cls.oauthlib_backend_class
 
     @classmethod
     def get_server(cls):


### PR DESCRIPTION
Developers can configure the ``oauthlib_backend_class`` used by ``OAuthLibMixin``. DOT generic views retrieve the ``oauthlib_backend_class`` instance through the ``OAUTH2_BACKEND_CLASS`` settings which is defaulted to ``oauth2_provider.oauth2_backends.OAuthLibCore``.

In this way, the RFC compliant ``OAuthLibCore`` class is used as a default, while developers can create or extend new implementations.

The ``oauth2_provider.oauth2_backends.JSONOAuthLibCore`` is provided and using it as a backend class, solves the issue #127. This approach accepts POST request using the ``application/json`` ``Content-Type`` for all token endpoints.

Before merging this PR we should:
* code review provided tests
* choose in which part of the documentation add the ``JSONOAuthLibCore`` example