### PR TITLE
wrong exception is sent due to separator being hard coded to "?" when raising an error

### DIFF
--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -157,8 +157,11 @@ class OAuthLibMixin(object):
         oauthlib_error = error.oauthlib_error
 
         separator = '?'
-        if '?' in oauthlib_error.redirect_uri:
-            separator = '&'
+        try:
+            if '?' in oauthlib_error.redirect_uri:
+                separator = '&'
+        except:
+            pass
 
         error_response = {
             'error': oauthlib_error,

--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -155,9 +155,14 @@ class OAuthLibMixin(object):
         :param error: :attr:`OAuthToolkitError`
         """
         oauthlib_error = error.oauthlib_error
+
+        separator = '?'
+        if '?' in oauthlib_error.redirect_uri:
+            separator = '&'
+
         error_response = {
             'error': oauthlib_error,
-            'url': "{0}?{1}".format(oauthlib_error.redirect_uri, oauthlib_error.urlencoded)
+            'url': "{0}{1}{2}".format(oauthlib_error.redirect_uri, separator, oauthlib_error.urlencoded)
         }
         error_response.update(kwargs)
 


### PR DESCRIPTION
This checks for the presence of a question mark in the URI and changes the separator accordingly so as to not put two questions marks in the URI.

fixes #238 