### PR TITLE
Issue #196 Add permission checking to application registration

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -40,12 +40,29 @@ this value if you wrote your own implementation (subclass of
 
 APPLICATION_REGISTRATION_PERMISSIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Which permissions are required to be able to register an application. By default
-only superusers or users with ```oauth2_provider | application | Can add application```
-permission are allowed to register applications. If this setting is set to ```None```
-then all authenticated users are allowed to register applications. For more information
-about setting more complex permissions see
+Defines which permissions are required to be able to register an application.
+By default every authenticated user is able to register applications.
+
+A common setup for none public sites might be to only allow superusers and users
+with the ```oauth2_provider | application | Can add application``` permission to be allowed
+to register applications.
+
+This can be done with the following configuration::
+
+    OAUTH2_PROVIDER = {
+        ...
+        'APPLICATION_REGISTRATION_PERMISSIONS': {
+            'all': ('oauth2_provider.add_application', ),
+        },
+        ...
+    }
+
+Following Django's auth system you can now either grant the ```oauth2_provider | application | Can add application```
+the a specific user or group to allow access to the application registration page.
+
+For more information about setting more complex permissions see
 `MultiplePermissionsRequiredMixin <https://django-braces.readthedocs.org/en/latest/access.html#multiplepermissionsrequiredmixin>`_.
+
 
 AUTHORIZATION_CODE_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -43,7 +43,7 @@ APPLICATION_REGISTRATION_PERMISSIONS
 Defines which permissions are required to be able to register an application.
 By default every authenticated user is able to register applications.
 
-A common setup for none public sites might be to only allow superusers and users
+A common setup for non public sites might be to only allow superusers and users
 with the ```oauth2_provider | application | Can add application``` permission to be allowed
 to register applications.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -38,6 +38,15 @@ The import string of the class (model) representing your applications. Overwrite
 this value if you wrote your own implementation (subclass of
 ``oauth2_provider.models.Application``).
 
+APPLICATION_REGISTRATION_PERMISSIONS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Which permissions are required to be able to register an application. By default
+only superusers or users with ```oauth2_provider | application | Can add application```
+permission are allowed to register applications. If this setting is set to ```None```
+then all authenticated users are allowed to register applications. For more information
+about setting more complex permissions see
+`MultiplePermissionsRequiredMixin <https://django-braces.readthedocs.org/en/latest/access.html#multiplepermissionsrequiredmixin>`_.
+
 AUTHORIZATION_CODE_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The number of seconds an authorization code remains valid. Requesting an access

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -42,9 +42,6 @@ DEFAULTS = {
     'ACCESS_TOKEN_EXPIRE_SECONDS': 36000,
     'APPLICATION_MODEL': getattr(settings, 'OAUTH2_PROVIDER_APPLICATION_MODEL', 'oauth2_provider.Application'),
     'APPLICATION_REGISTRATION_PERMISSIONS': None,
-    'APPLICATION_REGISTRATION_PERMISSIONS': {
-        'all': ('oauth2_provider.add_application', ),
-    },
     'REQUEST_APPROVAL_PROMPT': 'force',
     'ALLOWED_REDIRECT_URI_SCHEMES': ['http', 'https'],
 

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -41,6 +41,7 @@ DEFAULTS = {
     'AUTHORIZATION_CODE_EXPIRE_SECONDS': 60,
     'ACCESS_TOKEN_EXPIRE_SECONDS': 36000,
     'APPLICATION_MODEL': getattr(settings, 'OAUTH2_PROVIDER_APPLICATION_MODEL', 'oauth2_provider.Application'),
+    'APPLICATION_REGISTRATION_PERMISSIONS': None,
     'APPLICATION_REGISTRATION_PERMISSIONS': {
         'all': ('oauth2_provider.add_application', ),
     },

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -41,6 +41,9 @@ DEFAULTS = {
     'AUTHORIZATION_CODE_EXPIRE_SECONDS': 60,
     'ACCESS_TOKEN_EXPIRE_SECONDS': 36000,
     'APPLICATION_MODEL': getattr(settings, 'OAUTH2_PROVIDER_APPLICATION_MODEL', 'oauth2_provider.Application'),
+    'APPLICATION_REGISTRATION_PERMISSIONS': {
+        'all': ('oauth2_provider.add_application', ),
+    },
     'REQUEST_APPROVAL_PROMPT': 'force',
     'ALLOWED_REDIRECT_URI_SCHEMES': ['http', 'https'],
 

--- a/oauth2_provider/tests/test_application_views.py
+++ b/oauth2_provider/tests/test_application_views.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from ..models import get_application_model
@@ -14,6 +16,10 @@ class BaseTest(TestCase):
     def setUp(self):
         self.foo_user = UserModel.objects.create_user("foo_user", "test@user.com", "123456")
         self.bar_user = UserModel.objects.create_user("bar_user", "dev@user.com", "123456")
+
+        application_content_type = ContentType.objects.get_for_model(Application)
+        add_application_permission = Permission.objects.get(content_type=application_content_type, codename='add_application')
+        self.foo_user.user_permissions.add(add_application_permission)
 
     def tearDown(self):
         self.foo_user.delete()


### PR DESCRIPTION
Add an addition setting called APPLICATION_REGISTRATION_PERMISSIONS
which controls which permissions must be set on a user to allow the
creation of applications.

By default (in this PR) this is the 'add_application' permission which
regretfully is not backwards compatible but it does seem to make the
most sense from a security perspective as a default.

Reverting to the old behaviour is easily done by using None for the
settings key.