### PR TITLE
support/test django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,15 @@ env:
   - TOX_ENV=py27-django15
   - TOX_ENV=py27-django16
   - TOX_ENV=py27-django17
+  - TOX_ENV=py27-django18
   - TOX_ENV=py33-django15
   - TOX_ENV=py33-django16
   - TOX_ENV=py33-django17
+  - TOX_ENV=py33-django18
   - TOX_ENV=py34-django15
   - TOX_ENV=py34-django16
   - TOX_ENV=py34-django17
+  - TOX_ENV=py34-django18
   - TOX_ENV=docs
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Requirements
 ------------
 
 * Python 2.6, 2.7, 3.3, 3.4
-* Django 1.4, 1.5, 1.6, 1.7
+* Django 1.4, 1.5, 1.6, 1.7, 1.8
 
 Installation
 ------------

--- a/oauth2_provider/tests/test_client_credential.py
+++ b/oauth2_provider/tests/test_client_credential.py
@@ -110,6 +110,7 @@ class TestExtendedRequest(BaseTest):
     @classmethod
     def setUpClass(cls):
         cls.request_factory = RequestFactory()
+        super(TestExtendedRequest, cls).setUpClass()
 
     def test_extended_request(self):
         class TestView(OAuthLibMixin, View):

--- a/oauth2_provider/tests/test_decorators.py
+++ b/oauth2_provider/tests/test_decorators.py
@@ -19,6 +19,7 @@ class TestProtectedResourceDecorator(TestCase, TestCaseUtils):
     @classmethod
     def setUpClass(cls):
         cls.request_factory = RequestFactory()
+        super(TestProtectedResourceDecorator, cls).setUpClass()
 
     def setUp(self):
         self.user = UserModel.objects.create_user("test_user", "test@user.com", "123456")

--- a/oauth2_provider/tests/test_mixins.py
+++ b/oauth2_provider/tests/test_mixins.py
@@ -16,6 +16,7 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.request_factory = RequestFactory()
+        super(BaseTest, cls).setUpClass()
 
 
 class TestOAuthLibMixin(BaseTest):

--- a/oauth2_provider/tests/test_models.py
+++ b/oauth2_provider/tests/test_models.py
@@ -25,7 +25,7 @@ class TestModels(TestCase):
 
     def test_allow_scopes(self):
         self.client.login(username="test_user", password="123456")
-        app = Application(
+        app = Application.objects.create(
             name="test_app",
             redirect_uris="http://localhost http://example.com http://example.it",
             user=self.user,
@@ -96,10 +96,12 @@ class TestCustomApplicationModel(TestCase):
         See issue #90 (https://github.com/evonove/django-oauth-toolkit/issues/90)
         """
         # Django internals caches the related objects.
-        del UserModel._meta._related_objects_cache
+        if django.VERSION < (1, 8):
+            del UserModel._meta._related_objects_cache
         related_object_names = [ro.name for ro in UserModel._meta.get_all_related_objects()]
         self.assertNotIn('oauth2_provider:application', related_object_names)
-        self.assertIn('tests:testapplication', related_object_names)
+        self.assertIn('tests%stestapplication' % (':' if django.VERSION < (1, 8) else '_'),
+                      related_object_names)
 
 
 class TestGrantModel(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     py26-django14, py26-django15, py26-django16,
-    py27-django14, py27-django15, py27-django16, py27-django17,
-    py33-django15, py33-django16, py33-django17,
-    py34-django15, py34-django16, py34-django17,
+    py27-django14, py27-django15, py27-django16, py27-django17, py27-django18,
+    py33-django15, py33-django16, py33-django17, py33-django18,
+    py34-django15, py34-django16, py34-django17, py34-django18,
     docs,
     flake8
 
@@ -59,6 +59,12 @@ deps =
     Django<1.8
     {[testenv]deps}
 
+[testenv:py27-django18]
+basepython = python2.7
+deps =
+    Django<1.9
+    {[testenv]deps}
+
 [testenv:py33-django15]
 basepython = python3.3
 deps =
@@ -78,6 +84,12 @@ deps =
     Django<1.8
     {[testenv]deps}
 
+[testenv:py33-django18]
+basepython = python3.3
+deps =
+    Django<1.9
+    {[testenv]deps}
+
 [testenv:py34-django15]
 basepython = python3.4
 deps =
@@ -95,6 +107,12 @@ deps =
 basepython = python3.4
 deps =
     Django<1.8
+    {[testenv]deps}
+
+[testenv:py34-django18]
+basepython = python3.4
+deps =
+    Django<1.9
     {[testenv]deps}
 
 [testenv:docs]


### PR DESCRIPTION
This PR adds Django 1.8 to the test matrix and makes the necessary updates to keep the tests passing. It doesn't seem like any changes to the package code are necessary, just tests.