### PR TITLE
Fix the migrations to be two-step and allow upgrade from 0.7.2

### DIFF
--- a/oauth2_provider/migrations/0001_initial.py
+++ b/oauth2_provider/migrations/0001_initial.py
@@ -26,8 +26,7 @@ class Migration(migrations.Migration):
                 ('authorization_grant_type', models.CharField(max_length=32, choices=[('authorization-code', 'Authorization code'), ('implicit', 'Implicit'), ('password', 'Resource owner password-based'), ('client-credentials', 'Client credentials')])),
                 ('client_secret', models.CharField(default=oauth2_provider.generators.generate_client_secret, max_length=255, db_index=True, blank=True)),
                 ('name', models.CharField(max_length=255, blank=True)),
-                ('skip_authorization', models.BooleanField(default=False)),
-                ('user', models.ForeignKey(related_name='oauth2_provider_application', to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'abstract': False,
@@ -41,7 +40,7 @@ class Migration(migrations.Migration):
                 ('expires', models.DateTimeField()),
                 ('scope', models.TextField(blank=True)),
                 ('application', models.ForeignKey(to=oauth2_settings.APPLICATION_MODEL)),
-                ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
         ),
         migrations.CreateModel(

--- a/oauth2_provider/migrations/0002_08_updates.py
+++ b/oauth2_provider/migrations/0002_08_updates.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from oauth2_provider.settings import oauth2_settings
+from django.db import models, migrations
+import oauth2_provider.validators
+import oauth2_provider.generators
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oauth2_provider', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+             model_name='Application',
+             name='skip_authorization',
+             field=models.BooleanField(default=False),
+             preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='Application',
+            name='user',
+            field=models.ForeignKey(related_name='oauth2_provider_application', to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='AccessToken',
+            name='user',
+            field=models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
This splits the Django (non-South) migrations to ease the upgrade from 0.7.2 to 0.8.1+.

With this in place, one can fake the 0001 migration and then migrate to 0002 correctly, resulting in a correctly migrated app.