### PR TITLE
Generic read write scope by resource

### DIFF
--- a/docs/rest-framework/permissions.rst
+++ b/docs/rest-framework/permissions.rst
@@ -48,3 +48,18 @@ For example:
 
 When a request is performed both the `READ_SCOPE` \\ `WRITE_SCOPE` and 'music' scopes are required to be authorized for the current access token.
 
+TokenHasResourceScope
+----------------------
+The `TokenHasResourceScope` permission class allows the access only when the current access token has been authorized for **all** the scopes listed in the `required_scopes` field of the view but according of request's method.
+
+When the current request's method is one of the "safe" methods, the access is allowed only if the access token has been authorized for the `scope:read` scope (for example `music:read`).
+When the request's method is one of "non safe" methods, the access is allowed only if the access token has been authorizes for the `scope:write` scope (for example `music:write`).
+
+.. code-block:: python
+
+    class SongView(views.APIView):
+        authentication_classes = [OAuth2Authentication]
+        permission_classes = [TokenHasResourceScope]
+        required_scopes = ['music']
+
+The `required_scopes` attribute is mandatory (you just need inform the resource scope).

--- a/oauth2_provider/ext/rest_framework/__init__.py
+++ b/oauth2_provider/ext/rest_framework/__init__.py
@@ -1,2 +1,2 @@
 from .authentication import OAuth2Authentication
-from .permissions import TokenHasScope, TokenHasReadWriteScope
+from .permissions import TokenHasScope, TokenHasReadWriteScope, TokenHasResourceScope

--- a/oauth2_provider/ext/rest_framework/permissions.py
+++ b/oauth2_provider/ext/rest_framework/permissions.py
@@ -59,3 +59,28 @@ class TokenHasReadWriteScope(TokenHasScope):
             read_write_scope = oauth2_settings.WRITE_SCOPE
 
         return required_scopes + [read_write_scope]
+
+
+class TokenHasResourceScope(TokenHasScope):
+    """
+    The request is authenticated as a user and the token used has the right scope
+    """
+
+    def get_scopes(self, request, view):
+        try:
+            view_scopes = (
+                super(TokenHasResourceScope, self).get_scopes(request, view)
+            )
+        except ImproperlyConfigured:
+            view_scopes = []
+
+        if request.method.upper() in SAFE_HTTP_METHODS:
+            scope_type = oauth2_settings.READ_SCOPE
+        else:
+            scope_type = oauth2_settings.WRITE_SCOPE
+
+        required_scopes = [
+            '{0}:{1}'.format(scope, scope_type) for scope in view_scopes
+        ]
+
+        return required_scopes

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,3 +1,3 @@
 -r optional.txt
 coverage
-mock
+mock==1.0.1


### PR DESCRIPTION
I think it's a great feature, the idea in this pull request is working like the [github scopes](https://developer.github.com/v3/oauth/#scopes).

About mock library, I've opened a [pull request in mock repo](https://github.com/testing-cabal/mock/pull/265).