### PR TITLE
add wildcard * as option for redirect uri scheme settings

### DIFF
--- a/oauth2_provider/tests/test_validators.py
+++ b/oauth2_provider/tests/test_validators.py
@@ -25,6 +25,19 @@ class TestValidators(TestCase):
         # Check ValidationError not thrown
         validate_uris(good_uris)
 
+    def test_validate_wildcard_custom_uri_scheme(self):
+        oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES = ['*']
+        good_uris = 'my-scheme://example.com http://example.com'
+        # Check ValidationError not thrown
+        validate_uris(good_uris)
+
+    def test_validate_wildcard_bad_uris(self):
+        oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES = ['*']
+        bad_uri = 'http://example.com/#fragment'
+        self.assertRaises(ValidationError, validate_uris, bad_uri)
+        bad_uri = 'sdklfsjlfjljdflksjlkfjsdkl'
+        self.assertRaises(ValidationError, validate_uris, bad_uri)
+
     def test_validate_bad_uris(self):
         bad_uri = 'http://example.com/#fragment'
         self.assertRaises(ValidationError, validate_uris, bad_uri)

--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -52,7 +52,7 @@ class RedirectURIValidator(URIValidator):
         if len(value.split('#')) > 1:
             raise ValidationError('Redirect URIs must not contain fragments')
         scheme, netloc, path, query, fragment = urlsplit(value)
-        if scheme.lower() not in self.allowed_schemes:
+        if scheme.lower() not in self.allowed_schemes and '*' not in self.allowed_schemes:
             raise ValidationError('Redirect URI scheme is not allowed.')
 
 


### PR DESCRIPTION
This is how I patched the `__call__` method to check if the developer wanted to allow applications to specify arbitrary redirect uri schemes. 

For my purposes, I didn't want to update my app settings every time I modified a redirect scheme (lots of mobile development - so different schemes for each app). 