### PR TITLE
``server_class`` is now pluggable through Django settings

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -59,6 +59,11 @@ CLIENT_SECRET_GENERATOR_LENGTH
 The length of the generated secrets, in characters. If this value is too low,
 secrets may become subject to bruteforce guessing.
 
+OAUTH2_SERVER_CLASS
+~~~~~~~~~~~~~~~~~~~~
+The import string for the ``server_class`` (or ``oauthlib.oauth2.Server`` subclass)
+used in the ``OAuthLibMixin`` that implements OAuth2 grant types.
+
 OAUTH2_VALIDATOR_CLASS
 ~~~~~~~~~~~~~~~~~~~~~~
 The import string of the ``oauthlib.oauth2.RequestValidator`` subclass that

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -18,7 +18,7 @@ class OAuthLibCore(object):
         """
         :params server: An instance of oauthlib.oauth2.Server class
         """
-        self.server = server or oauth2.Server(oauth2_settings.OAUTH2_VALIDATOR_CLASS())
+        self.server = server or oauth2_settings.OAUTH2_SERVER_CLASS(oauth2_settings.OAUTH2_VALIDATOR_CLASS())
 
     def _get_escaped_full_path(self, request):
         """
@@ -179,7 +179,6 @@ def get_oauthlib_core():
     Utility function that take a request and returns an instance of
     `oauth2_provider.backends.OAuthLibCore`
     """
-    from oauthlib.oauth2 import Server
-
-    server = Server(oauth2_settings.OAUTH2_VALIDATOR_CLASS())
+    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
+    server = oauth2_settings.OAUTH2_SERVER_CLASS(validator)
     return oauth2_settings.OAUTH2_BACKEND_CLASS(server)

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -33,6 +33,7 @@ DEFAULTS = {
     'CLIENT_ID_GENERATOR_CLASS': 'oauth2_provider.generators.ClientIdGenerator',
     'CLIENT_SECRET_GENERATOR_CLASS': 'oauth2_provider.generators.ClientSecretGenerator',
     'CLIENT_SECRET_GENERATOR_LENGTH': 128,
+    'OAUTH2_SERVER_CLASS': 'oauthlib.oauth2.Server',
     'OAUTH2_VALIDATOR_CLASS': 'oauth2_provider.oauth2_validators.OAuth2Validator',
     'OAUTH2_BACKEND_CLASS': 'oauth2_provider.oauth2_backends.OAuthLibCore',
     'SCOPES': {"read": "Reading scope", "write": "Writing scope"},
@@ -52,6 +53,7 @@ DEFAULTS = {
 MANDATORY = (
     'CLIENT_ID_GENERATOR_CLASS',
     'CLIENT_SECRET_GENERATOR_CLASS',
+    'OAUTH2_SERVER_CLASS',
     'OAUTH2_VALIDATOR_CLASS',
     'OAUTH2_BACKEND_CLASS',
     'SCOPES',
@@ -62,6 +64,7 @@ MANDATORY = (
 IMPORT_STRINGS = (
     'CLIENT_ID_GENERATOR_CLASS',
     'CLIENT_SECRET_GENERATOR_CLASS',
+    'OAUTH2_SERVER_CLASS',
     'OAUTH2_VALIDATOR_CLASS',
     'OAUTH2_BACKEND_CLASS',
 )

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -6,8 +6,6 @@ from django.views.generic import View, FormView
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 
-from oauthlib.oauth2 import Server
-
 from braces.views import LoginRequiredMixin, CsrfExemptMixin
 
 from ..settings import oauth2_settings
@@ -71,7 +69,7 @@ class AuthorizationView(BaseAuthorizationView, FormView):
     template_name = 'oauth2_provider/authorize.html'
     form_class = AllowForm
 
-    server_class = Server
+    server_class = oauth2_settings.OAUTH2_SERVER_CLASS
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
     oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 
@@ -163,7 +161,7 @@ class TokenView(CsrfExemptMixin, OAuthLibMixin, View):
     * Password
     * Client credentials
     """
-    server_class = Server
+    server_class = oauth2_settings.OAUTH2_SERVER_CLASS
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
     oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 
@@ -181,7 +179,7 @@ class RevokeTokenView(CsrfExemptMixin, OAuthLibMixin, View):
     """
     Implements an endpoint to revoke access or refresh tokens
     """
-    server_class = Server
+    server_class = oauth2_settings.OAUTH2_SERVER_CLASS
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
     oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 

--- a/oauth2_provider/views/generic.py
+++ b/oauth2_provider/views/generic.py
@@ -1,7 +1,5 @@
 from django.views.generic import View
 
-from oauthlib.oauth2 import Server
-
 from ..settings import oauth2_settings
 from .mixins import ProtectedResourceMixin, ScopedResourceMixin, ReadWriteScopedResourceMixin
 
@@ -10,7 +8,7 @@ class ProtectedResourceView(ProtectedResourceMixin, View):
     """
     Generic view protecting resources by providing OAuth2 authentication out of the box
     """
-    server_class = Server
+    server_class = oauth2_settings.OAUTH2_SERVER_CLASS
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
     oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 


### PR DESCRIPTION
Hi!

In my pull request you can find some little changes that allow to override ``server_class`` that used in ``OAuthLibMixin``. These changes are very useful for some projects which want to implement custom grant types and the best way to do this — implement own ``server_class`` based on ``oauthlib.oauth2.Server``.

Please let me know if you have any questions or I forgot to do something.
If I need to write tests according to my changes, please give me an advice what tests you want to see.

Thanks.