### PR TITLE
Prepare the Django 1.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python: "2.7"
+sudo: false
 
 env:
   - TOX_ENV=py26-django14

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
   - TOX_ENV=py34-django17
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19
-  - TOX_ENV=py35-django19
   - TOX_ENV=docs
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,17 @@ env:
   - TOX_ENV=py27-django16
   - TOX_ENV=py27-django17
   - TOX_ENV=py27-django18
+  - TOX_ENV=py27-django19
   - TOX_ENV=py33-django15
   - TOX_ENV=py33-django16
   - TOX_ENV=py33-django17
   - TOX_ENV=py33-django18
+  - TOX_ENV=py33-django19
   - TOX_ENV=py34-django15
   - TOX_ENV=py34-django16
   - TOX_ENV=py34-django17
   - TOX_ENV=py34-django18
+  - TOX_ENV=py34-django19
   - TOX_ENV=docs
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ env:
   - TOX_ENV=py33-django16
   - TOX_ENV=py33-django17
   - TOX_ENV=py33-django18
-  - TOX_ENV=py33-django19
   - TOX_ENV=py34-django15
   - TOX_ENV=py34-django16
   - TOX_ENV=py34-django17
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19
+  - TOX_ENV=py35-django19
   - TOX_ENV=docs
 
 install:

--- a/oauth2_provider/compat.py
+++ b/oauth2_provider/compat.py
@@ -43,3 +43,9 @@ if django.VERSION >= (1, 5):
     from django.template.defaulttags import url
 else:
     from django.templatetags.future import url
+
+# Django 1.9 drops the NullHandler since Python 2.7 includes it
+try:
+    from logging import NullHandler
+except ImportError:
+    from django.utils.log import NullHandler

--- a/oauth2_provider/compat.py
+++ b/oauth2_provider/compat.py
@@ -37,3 +37,9 @@ try:
     get_model = apps.get_model
 except ImportError:
     from django.db.models import get_model
+
+# Django 1.5 add the support of context variables for the url template tag
+if django.VERSION >= (1, 5):
+    from django.template.defaulttags import url
+else:
+    from django.templatetags.future import url

--- a/oauth2_provider/compat.py
+++ b/oauth2_provider/compat.py
@@ -43,9 +43,3 @@ if django.VERSION >= (1, 5):
     from django.template.defaulttags import url
 else:
     from django.templatetags.future import url
-
-# Django 1.9 drops the NullHandler since Python 2.7 includes it
-try:
-    from logging import NullHandler
-except ImportError:
-    from django.utils.log import NullHandler

--- a/oauth2_provider/compat_handlers.py
+++ b/oauth2_provider/compat_handlers.py
@@ -1,0 +1,5 @@
+# Django 1.9 drops the NullHandler since Python 2.7 includes it
+try:
+    from logging import NullHandler
+except ImportError:
+    from django.utils.log import NullHandler

--- a/oauth2_provider/templates/oauth2_provider/application_confirm_delete.html
+++ b/oauth2_provider/templates/oauth2_provider/application_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "oauth2_provider/base.html" %}
 
 {% load i18n %}
-{% load url from future %}
+{% load url from compat %}
 {% block content %}
     <div class="block-center">
         <h3 class="block-center-heading">{% trans "Are you sure to delete the application" %} {{ application.name }}?</h3>

--- a/oauth2_provider/templates/oauth2_provider/application_detail.html
+++ b/oauth2_provider/templates/oauth2_provider/application_detail.html
@@ -1,7 +1,7 @@
 {% extends "oauth2_provider/base.html" %}
 
 {% load i18n %}
-{% load url from future %}
+{% load url from compat %}
 {% block content %}
     <div class="block-center">
         <h3 class="block-center-heading">{{ application.name }}</h3>

--- a/oauth2_provider/templates/oauth2_provider/application_form.html
+++ b/oauth2_provider/templates/oauth2_provider/application_form.html
@@ -1,7 +1,7 @@
 {% extends "oauth2_provider/base.html" %}
 
 {% load i18n %}
-{% load url from future %}
+{% load url from compat %}
 {% block content %}
     <div class="block-center">
         <form class="form-horizontal" method="post" action="{% block app-form-action-url %}{% url 'oauth2_provider:update' application.id %}{% endblock app-form-action-url %}">

--- a/oauth2_provider/templates/oauth2_provider/application_list.html
+++ b/oauth2_provider/templates/oauth2_provider/application_list.html
@@ -1,7 +1,7 @@
 {% extends "oauth2_provider/base.html" %}
 
 {% load i18n %}
-{% load url from future %}
+{% load url from compat %}
 {% block content %}
     <div class="block-center">
         <h3 class="block-center-heading">{% trans "Your applications" %}</h3>

--- a/oauth2_provider/templates/oauth2_provider/application_registration_form.html
+++ b/oauth2_provider/templates/oauth2_provider/application_registration_form.html
@@ -1,7 +1,7 @@
 {% extends "oauth2_provider/application_form.html" %}
 
 {% load i18n %}
-{% load url from future %}
+{% load url from compat %}
 
 {% block app-form-title %}{% trans "Register a new application" %}{% endblock app-form-title %}
 

--- a/oauth2_provider/templatetags/compat.py
+++ b/oauth2_provider/templatetags/compat.py
@@ -1,0 +1,10 @@
+from django import template
+
+from ..compat import url as url_compat
+
+register = template.Library()
+
+
+@register.tag
+def url(parser, token):
+    return url_compat(parser, token)

--- a/oauth2_provider/tests/settings.py
+++ b/oauth2_provider/tests/settings.py
@@ -100,7 +100,7 @@ LOGGING = {
         },
         'null': {
             'level': 'DEBUG',
-            'class': 'oauth2_provider.compat.NullHandler',
+            'class': 'oauth2_provider.compat_handlers.NullHandler',
         },
     },
     'loggers': {

--- a/oauth2_provider/tests/settings.py
+++ b/oauth2_provider/tests/settings.py
@@ -100,7 +100,7 @@ LOGGING = {
         },
         'null': {
             'level': 'DEBUG',
-            'class': 'django.utils.log.NullHandler',
+            'class': 'logging.NullHandler',
         },
     },
     'loggers': {

--- a/oauth2_provider/tests/settings.py
+++ b/oauth2_provider/tests/settings.py
@@ -100,7 +100,7 @@ LOGGING = {
         },
         'null': {
             'level': 'DEBUG',
-            'class': 'logging.NullHandler',
+            'class': 'oauth2_provider.compat.NullHandler',
         },
     },
     'loggers': {

--- a/oauth2_provider/tests/test_auth_backends.py
+++ b/oauth2_provider/tests/test_auth_backends.py
@@ -76,7 +76,7 @@ class TestOAuth2Backend(BaseTest):
         'oauth2_provider.backends.OAuth2Backend',
         'django.contrib.auth.backends.ModelBackend',
     ),
-    MIDDLEWARE_CLASSES=MIDDLEWARE_CLASSES + ('oauth2_provider.middleware.OAuth2TokenMiddleware',)
+    MIDDLEWARE_CLASSES=tuple(MIDDLEWARE_CLASSES) + ('oauth2_provider.middleware.OAuth2TokenMiddleware',)
 )
 class TestOAuth2Middleware(BaseTest):
 

--- a/oauth2_provider/tests/test_rest_framework.py
+++ b/oauth2_provider/tests/test_rest_framework.py
@@ -3,8 +3,12 @@ from datetime import timedelta
 from django.conf.urls import patterns, url, include
 from django.http import HttpResponse
 from django.test import TestCase
-from django.utils import timezone, unittest
+from django.utils import timezone
 
+try:
+    import unittest
+except ImportError:
+    from django.utils import unittest
 
 from .test_utils import TestCaseUtils
 from ..models import AccessToken, get_application_model

--- a/oauth2_provider/tests/test_rest_framework.py
+++ b/oauth2_provider/tests/test_rest_framework.py
@@ -6,9 +6,9 @@ from django.test import TestCase
 from django.utils import timezone
 
 try:
-    import unittest
-except ImportError:
     from django.utils import unittest
+except ImportError:
+    import unittest
 
 from .test_utils import TestCaseUtils
 from ..models import AccessToken, get_application_model

--- a/oauth2_provider/tests/urls.py
+++ b/oauth2_provider/tests/urls.py
@@ -1,11 +1,10 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 admin.autodiscover()
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = (
     url(r'^admin/', include(admin.site.urls)),
     url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 )

--- a/oauth2_provider/urls.py
+++ b/oauth2_provider/urls.py
@@ -1,18 +1,16 @@
 from __future__ import absolute_import
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = (
     url(r'^authorize/$', views.AuthorizationView.as_view(), name="authorize"),
     url(r'^token/$', views.TokenView.as_view(), name="token"),
     url(r'^revoke_token/$', views.RevokeTokenView.as_view(), name="revoke-token"),
 )
 
 # Application management views
-urlpatterns += patterns(
-    '',
+urlpatterns += (
     url(r'^applications/$', views.ApplicationList.as_view(), name="list"),
     url(r'^applications/register/$', views.ApplicationRegistration.as_view(), name="register"),
     url(r'^applications/(?P<pk>\d+)/$', views.ApplicationDetail.as_view(), name="detail"),

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     py26-django14, py26-django15, py26-django16,
-    py27-django14, py27-django15, py27-django16, py27-django17, py27-django18,
-    py33-django15, py33-django16, py33-django17, py33-django18,
-    py34-django15, py34-django16, py34-django17, py34-django18,
+    py27-django14, py27-django15, py27-django16, py27-django17, py27-django18, py27-django19,
+    py33-django15, py33-django16, py33-django17, py33-django18, py33-django19,
+    py34-django15, py34-django16, py34-django17, py34-django18, py34-django19,
     docs,
     flake8
 
@@ -65,6 +65,12 @@ deps =
     Django<1.9
     {[testenv]deps}
 
+[testenv:py27-django19]
+basepython = python2.7
+deps =
+    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
+    {[testenv]deps}
+
 [testenv:py33-django15]
 basepython = python3.3
 deps =
@@ -90,6 +96,12 @@ deps =
     Django<1.9
     {[testenv]deps}
 
+[testenv:py33-django19]
+basepython = python3.3
+deps =
+    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
+    {[testenv]deps}
+
 [testenv:py34-django15]
 basepython = python3.4
 deps =
@@ -113,6 +125,12 @@ deps =
 basepython = python3.4
 deps =
     Django<1.9
+    {[testenv]deps}
+
+[testenv:py34-django19]
+basepython = python3.4
+deps =
+    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
     {[testenv]deps}
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -97,12 +97,6 @@ deps =
     Django<1.9
     {[testenv]deps}
 
-[testenv:py33-django19]
-basepython = python3.3
-deps =
-    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
-    {[testenv]deps}
-
 [testenv:py34-django15]
 basepython = python3.4
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 envlist =
     py26-django14, py26-django15, py26-django16,
     py27-django14, py27-django15, py27-django16, py27-django17, py27-django18, py27-django19,
-    py33-django15, py33-django16, py33-django17, py33-django18, py33-django19,
+    py33-django15, py33-django16, py33-django17, py33-django18,
     py34-django15, py34-django16, py34-django17, py34-django18, py34-django19,
+    py35-django19,
     docs,
     flake8
 
@@ -129,6 +130,12 @@ deps =
 
 [testenv:py34-django19]
 basepython = python3.4
+deps =
+    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
+    {[testenv]deps}
+
+[testenv:py35-django19]
+basepython = python3.5
 deps =
     git+https://github.com/django/django.git@stable/1.9.x#egg=Django
     {[testenv]deps}


### PR DESCRIPTION
`urlpatterns` should be a plain list or `django.conf.urls.url` instances.

> As stated by the [Django documentation](https://docs.djangoproject.com/en/1.9/ref/urls/), and Django 1.9 will probably remove it.

Cheers