### PR TITLE
Use compact syntax for tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    py26-django14, py26-django15, py26-django16,
-    py27-django14, py27-django15, py27-django16, py27-django17, py27-django18, py27-django19,
-    py33-django15, py33-django16, py33-django17, py33-django18,
-    py34-django15, py34-django16, py34-django17, py34-django18, py34-django19,
-    py35-django19,
+    {py26}-django{14,15,16},
+    {py27}-django{14,15,16,17,18,19},
+    {py33}-django{15,16,17,18},
+    {py34}-django{15,16,17,18,19},
+    {py35}-django{19},
     docs,
     flake8
 


### PR DESCRIPTION
I came across this syntax minutes ago, it can be easier to read and avoid annoying typo mistakes.

Cheers