### PR TITLE
Add the py35-django19 env to travis but allow it to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,14 @@ env:
   - TOX_ENV=py34-django17
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19
+  - TOX_ENV=py35-django19
   - TOX_ENV=docs
+
+matrix:
+  # Python 3.5 not yet available on travis, watch this to see when it is.
+  fast_finish: true
+  allow_failures:
+    - env: TOX_ENV=py35-django19
 
 install:
   - pip install tox


### PR DESCRIPTION
Be ready for the integration of Python 3.5.
This way, we keep an eye when looking for ci builds, and we'll only need to remove the `allow_failures` key in `travis.yml`.