### PR TITLE
Fixed error that could occur sometimes when checking validity of incomplete AccessToken/Grant

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -155,6 +155,9 @@ class Grant(models.Model):
         """
         Check token expiration with timezone awareness
         """
+        if not self.expires:
+            return True
+            
         return timezone.now() >= self.expires
 
     def redirect_uri_allowed(self, uri):
@@ -196,6 +199,9 @@ class AccessToken(models.Model):
         """
         Check token expiration with timezone awareness
         """
+        if not self.expires:
+            return True
+        
         return timezone.now() >= self.expires
 
     def allow_scopes(self, scopes):

--- a/oauth2_provider/tests/test_models.py
+++ b/oauth2_provider/tests/test_models.py
@@ -109,6 +109,11 @@ class TestGrantModel(TestCase):
     def test_str(self):
         grant = Grant(code="test_code")
         self.assertEqual("%s" % grant, grant.code)
+    
+    def test_expires_can_be_none(self):
+        grant = Grant(code="test_code")
+        self.assertIsNone(grant.expires)
+        self.assertFalse(grant.is_expired())
 
 
 class TestAccessTokenModel(TestCase):
@@ -129,6 +134,11 @@ class TestAccessTokenModel(TestCase):
         )
         access_token = AccessToken.objects.create(token="test_token", application=app, expires=timezone.now())
         self.assertIsNone(access_token.user)
+    
+    def test_expires_can_be_none(self):
+        access_token = AccessToken(token="test_token")
+        self.assertIsNone(access_token.expires)
+        self.assertFalse(access_token.is_expired())
 
 
 class TestRefreshTokenModel(TestCase):

--- a/oauth2_provider/tests/test_models.py
+++ b/oauth2_provider/tests/test_models.py
@@ -113,7 +113,7 @@ class TestGrantModel(TestCase):
     def test_expires_can_be_none(self):
         grant = Grant(code="test_code")
         self.assertIsNone(grant.expires)
-        self.assertFalse(grant.is_expired())
+        self.assertTrue(grant.is_expired())
 
 
 class TestAccessTokenModel(TestCase):
@@ -138,7 +138,7 @@ class TestAccessTokenModel(TestCase):
     def test_expires_can_be_none(self):
         access_token = AccessToken(token="test_token")
         self.assertIsNone(access_token.expires)
-        self.assertFalse(access_token.is_expired())
+        self.assertTrue(access_token.is_expired())
 
 
 class TestRefreshTokenModel(TestCase):


### PR DESCRIPTION
If AccessToken/Grant had, for whatever reason, no "expires" the is_expired check would fail with a TypeError(can't compare datetime.datetime to NoneType).