### PR TITLE
Improve django-rest-framework support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Ash Christopher
 Rodney Richardson
 Hiroki Kiyohara
 Diego Garcia
+Pierre Dulac

--- a/docs/rest-framework/getting_started.rst
+++ b/docs/rest-framework/getting_started.rst
@@ -104,6 +104,7 @@ Also add the following to your `settings.py` module:
     OAUTH2_PROVIDER = {
         # this is the list of available scopes
         'SCOPES': {'read': 'Read scope', 'write': 'Write scope', 'groups': 'Access to your groups'}
+        'OAUTH2_BACKEND_CLASS': 'oauth2_provider.ext.rest_framework.oauth2_backends.OAuthLibCore',
     }
 
     REST_FRAMEWORK = {

--- a/oauth2_provider/ext/rest_framework/authentication.py
+++ b/oauth2_provider/ext/rest_framework/authentication.py
@@ -1,4 +1,7 @@
+from django.utils.translation import ugettext_lazy as _
+
 from rest_framework.authentication import BaseAuthentication
+from rest_framework import exceptions
 
 from ...oauth2_backends import get_oauthlib_core
 
@@ -16,10 +19,14 @@ class OAuth2Authentication(BaseAuthentication):
         """
         oauthlib_core = get_oauthlib_core()
         valid, r = oauthlib_core.verify_request(request, scopes=[])
-        if valid:
-            return r.user, r.access_token
-        else:
+
+        if not valid:
             return None
+
+        if not r.user.is_active:
+            raise exceptions.AuthenticationFailed(_('User inactive or deleted.'))
+
+        return r.user, r.access_token
 
     def authenticate_header(self, request):
         """

--- a/oauth2_provider/ext/rest_framework/oauth2_backends.py
+++ b/oauth2_provider/ext/rest_framework/oauth2_backends.py
@@ -15,5 +15,12 @@ class OAuthLibCore(oauth2_backends.OAuthLibCore):
             for authentication and not pass the credentials in the request body
         """
         if isinstance(request, Request):
-            return request.data.items()
+            try:
+                # support DRF 2.x
+                if not hasattr(request, 'data'):
+                    return request.DATA.items()
+                return request.data.items()
+            except (ValueError, AttributeError):
+                # complex json request (list?) is not easily serializable
+                return ""
         return super(OAuthLibCore, self).extract_body(request)

--- a/oauth2_provider/ext/rest_framework/oauth2_backends.py
+++ b/oauth2_provider/ext/rest_framework/oauth2_backends.py
@@ -1,0 +1,19 @@
+from rest_framework.request import Request
+from oauth2_provider import oauth2_backends
+
+
+class OAuthLibCore(oauth2_backends.OAuthLibCore):
+    """Backend for Django Rest Framework"""
+
+    def extract_body(self, request):
+        """
+        We can read only once the body in Django, 
+        so in case of DRF we avoid to read it before the framework does.
+        This use case often happen during multipart form requests.
+
+        NB: it forces you to use the `Authorization` request header 
+            for authentication and not pass the credentials in the request body
+        """
+        if isinstance(request, Request):
+            return request.data.items()
+        return super(OAuthLibCore, self).extract_body(request)


### PR DESCRIPTION
Hi guys,

I stubbled across some difficulties with DRF, and since you have an integration guide with it I think it could be helpful to bring some updates.

With multipart form requests I had an odd issue, because the request body was read by DOT before letting the form parser read it. It has been reported in #296, but no pull request associated, so here it is.

And I've added a little addition to the `OAuth2Authentication` class to reject non active users (thanks to @pySilver for the heads-up).

Cheers :beers: 
