### PR TITLE
RegistrationForm should use custom Application model

### DIFF
--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 
-from .models import Application
+from .models import get_application_model
+
+Application = get_application_model()
 
 
 class AllowForm(forms.Form):

--- a/oauth2_provider/tests/settings.py
+++ b/oauth2_provider/tests/settings.py
@@ -121,6 +121,8 @@ OAUTH2_PROVIDER = {
     '_SCOPES': ['example']
 }
 
+OAUTH2_PROVIDER_APPLICATION_MODEL = 'tests.TestApplication'
+
 import django
 
 if django.VERSION[:2] < (1, 6):


### PR DESCRIPTION
This is a fix for #274.  All tests pass so unless the author of https://github.com/evonove/django-oauth-toolkit/commit/f5a1a493b939447076cb7af7553522b398b1d1eb can provide a failing test, I think the custom application model support should be restored.  This is really a bug that completely breaks custom application model use in registration