### PR TITLE
added missing swappable migration option

### DIFF
--- a/oauth2_provider/migrations/0001_initial.py
+++ b/oauth2_provider/migrations/0001_initial.py
@@ -30,6 +30,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'abstract': False,
+                'swappable': 'OAUTH2_PROVIDER_APPLICATION_MODEL',
             },
         ),
         migrations.CreateModel(


### PR DESCRIPTION
This migration option prevents the creation of the Application model if an alternative model is already provided.

The swappable option is already set in models.py, it was only missing in the initial migration.