### PR TITLE
Fix #340 by defaulting encoding var when request.encoding is None

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -7,6 +7,7 @@ import logging
 from datetime import timedelta
 
 from django.utils import timezone
+from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ObjectDoesNotExist
 from oauthlib.oauth2 import RequestValidator
@@ -57,7 +58,7 @@ class OAuth2Validator(RequestValidator):
             return False
 
         try:
-            encoding = request.encoding
+            encoding = request.encoding or settings.DEFAULT_CHARSET or 'utf-8'
         except AttributeError:
             encoding = 'utf-8'
 

--- a/oauth2_provider/tests/test_oauth2_validators.py
+++ b/oauth2_provider/tests/test_oauth2_validators.py
@@ -53,6 +53,12 @@ class TestOAuth2Validator(TestCase):
         self.request.headers = {'HTTP_AUTHORIZATION': 'Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=\n'}
         self.assertTrue(self.validator._authenticate_basic_auth(self.request))
 
+    def test_authenticate_basic_auth_default_encoding(self):
+        self.request.encoding = None
+        # client_id:client_secret
+        self.request.headers = {'HTTP_AUTHORIZATION': 'Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=\n'}
+        self.assertTrue(self.validator._authenticate_basic_auth(self.request))
+
     def test_authenticate_basic_auth_wrong_client_id(self):
         self.request.encoding = 'utf-8'
         # wrong_id:client_secret


### PR DESCRIPTION
`None` is a valid value for `request.encoding`, as documented: https://docs.djangoproject.com/en/1.9/ref/request-response/#django.http.HttpRequest.encoding)