### PR TITLE
Made all models swappable

### DIFF
--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -1,12 +1,16 @@
 from django.contrib import admin
 
-from .models import Grant, AccessToken, RefreshToken, get_application_model
+from .models import (get_grant_model, get_access_token_model,
+                     get_refersh_token_model, get_application_model)
 
 
 class RawIDAdmin(admin.ModelAdmin):
     raw_id_fields = ('user',)
 
 Application = get_application_model()
+Grant = get_grant_model()
+AccessToken = get_access_token_model()
+RefreshToken = get_refersh_token_model()
 
 admin.site.register(Application, RawIDAdmin)
 admin.site.register(Grant, RawIDAdmin)

--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
 from .models import (get_grant_model, get_access_token_model,
-                     get_refersh_token_model, get_application_model)
+                     get_refresh_token_model, get_application_model)
 
 
 class RawIDAdmin(admin.ModelAdmin):

--- a/oauth2_provider/migrations/0001_initial.py
+++ b/oauth2_provider/migrations/0001_initial.py
@@ -13,6 +13,9 @@ class Migration(migrations.Migration):
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         migrations.swappable_dependency(oauth2_settings.APPLICATION_MODEL),
+        migrations.swappable_dependency(oauth2_settings.GRANT_MODEL),
+        migrations.swappable_dependency(oauth2_settings.ACCESS_TOKEN_MODEL),
+        migrations.swappable_dependency(oauth2_settings.REFRESH_TOKEN_MODEL),
     ]
 
     operations = [
@@ -43,6 +46,10 @@ class Migration(migrations.Migration):
                 ('application', models.ForeignKey(to=oauth2_settings.APPLICATION_MODEL)),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
+            options={
+                'abstract': False,
+                'swappable': 'OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL',
+            },
         ),
         migrations.CreateModel(
             name='Grant',
@@ -55,15 +62,23 @@ class Migration(migrations.Migration):
                 ('application', models.ForeignKey(to=oauth2_settings.APPLICATION_MODEL)),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
+            options={
+                'abstract': False,
+                'swappable': 'OAUTH2_PROVIDER_GRANT_MODEL',
+            },
         ),
         migrations.CreateModel(
             name='RefreshToken',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('token', models.CharField(max_length=255, db_index=True)),
-                ('access_token', models.OneToOneField(related_name='refresh_token', to='oauth2_provider.AccessToken')),
+                ('access_token', models.OneToOneField(related_name='refresh_token', to=oauth2_settings.ACCESS_TOKEN_MODEL)),
                 ('application', models.ForeignKey(to=oauth2_settings.APPLICATION_MODEL)),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
+            options={
+                'abstract': False,
+                'swappable': 'OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL',
+            },
         ),
     ]

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -127,7 +127,7 @@ class Application(AbstractApplication):
     pass
 
 # Add swappable like this to not break django 1.4 compatibility
-Application._meta.swappable = 'OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL'
+Application._meta.swappable = 'OAUTH2_PROVIDER_APPLICATION_MODEL'
 
 
 @python_2_unicode_compatible
@@ -299,11 +299,11 @@ def get_application_model():
     try:
         app_label, model_name = oauth2_settings.APPLICATION_MODEL.split('.')
     except ValueError:
-        e = "ACCESS_TOKEN_MODEL must be of the form 'app_label.model_name'"
+        e = "APPLICATION_MODEL must be of the form 'app_label.model_name'"
         raise ImproperlyConfigured(e)
     app_model = get_model(app_label, model_name)
     if app_model is None:
-        e = "ACCESS_TOKEN_MODEL refers to model {0} that has not been installed"
+        e = "APPLICATION_MODEL refers to model {0} that has not been installed"
         raise ImproperlyConfigured(e.format(oauth2_settings.APPLICATION_MODEL))
     return app_model
 

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -44,6 +44,9 @@ DEFAULTS = {
     'ACCESS_TOKEN_EXPIRE_SECONDS': 36000,
     'REFRESH_TOKEN_EXPIRE_SECONDS': None,
     'APPLICATION_MODEL': getattr(settings, 'OAUTH2_PROVIDER_APPLICATION_MODEL', 'oauth2_provider.Application'),
+    'GRANT_MODEL': getattr(settings, 'OAUTH2_PROVIDER_GRANT_MODEL', 'oauth2_provider.Grant'),
+    'ACCESS_TOKEN_MODEL': getattr(settings, 'OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL', 'oauth2_provider.AccessToken'),
+    'REFRESH_TOKEN_MODEL': getattr(settings, 'OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL', 'oauth2_provider.RefreshToken'),
     'REQUEST_APPROVAL_PROMPT': 'force',
     'ALLOWED_REDIRECT_URI_SCHEMES': ['http', 'https'],
 

--- a/oauth2_provider/south_migrations/0001_initial.py
+++ b/oauth2_provider/south_migrations/0001_initial.py
@@ -11,9 +11,14 @@ except ImportError:  # django < 1.5
 else:
     User = get_user_model()
 
-from oauth2_provider.models import get_application_model
+from oauth2_provider.models import (get_application_model,
+                                    get_access_token_model,
+                                    get_grant_model,
+                                    get_refersh_token_model)
 ApplicationModel = get_application_model()
-
+GrantModel = get_grant_model()
+AccessTokenModel = get_access_token_model()
+RefreshTokenModel = get_refersh_token_model
 
 class Migration(SchemaMigration):
 
@@ -60,7 +65,7 @@ class Migration(SchemaMigration):
             ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm["%s.%s" % (User._meta.app_label, User._meta.object_name)])),
             ('token', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('application', self.gf('django.db.models.fields.related.ForeignKey')(to=orm["%s.%s" % (ApplicationModel._meta.app_label, ApplicationModel._meta.object_name)])),
-            ('access_token', self.gf('django.db.models.fields.related.OneToOneField')(related_name='refresh_token', unique=True, to=orm['oauth2_provider.AccessToken'])),
+            ('access_token', self.gf('django.db.models.fields.related.OneToOneField')(related_name='refresh_token', unique=True, to=ormorm["%s.%s" % (AccessTokenModel._meta.app_label, AccessTokenModel._meta.object_name)])),
         ))
         db.send_create_signal(u'oauth2_provider', ['RefreshToken'])
 
@@ -116,8 +121,8 @@ class Migration(SchemaMigration):
             'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
         },
-        u'oauth2_provider.accesstoken': {
-            'Meta': {'object_name': 'AccessToken'},
+        u"%s.%s" % (AccessTokenModel._meta.app_label, AccessTokenModel._meta.object_name): {
+            'Meta': {'object_name': AccessTokenModel.__name__},
             'application': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['%s.%s']"% (ApplicationModel._meta.app_label, ApplicationModel._meta.object_name)}),
             'expires': ('django.db.models.fields.DateTimeField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
@@ -136,8 +141,8 @@ class Migration(SchemaMigration):
             'redirect_uris': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['%s.%s']"% (User._meta.app_label, User._meta.object_name)})
         },
-        u'oauth2_provider.grant': {
-            'Meta': {'object_name': 'Grant'},
+        u"%s.%s" % (GrantModel._meta.app_label, GrantModel._meta.object_name)': {
+            'Meta': {'object_name': GrantModel.__name__},
             'application': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['%s.%s']"% (ApplicationModel._meta.app_label, ApplicationModel._meta.object_name)}),
             'code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'expires': ('django.db.models.fields.DateTimeField', [], {}),
@@ -146,9 +151,9 @@ class Migration(SchemaMigration):
             'scope': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['%s.%s']"% (User._meta.app_label, User._meta.object_name)})
         },
-        u'oauth2_provider.refreshtoken': {
-            'Meta': {'object_name': 'RefreshToken'},
-            'access_token': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'refresh_token'", 'unique': 'True', 'to': u"orm['oauth2_provider.AccessToken']"}),
+        u"%s.%s" % (RefreshTokenModel._meta.app_label, RefreshTokenModel._meta.object_name)': {
+            'Meta': {'object_name': RefreshTokenModel.__name__},
+            'access_token': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'refresh_token'", 'unique': 'True', 'to': {'to': u"orm['%s.%s']"% (AccessTokenModel._meta.app_label, AccessTokenModel._meta.object_name)}}),
             'application': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['%s.%s']"% (ApplicationModel._meta.app_label, ApplicationModel._meta.object_name)}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'token': ('django.db.models.fields.CharField', [], {'max_length': '255'}),

--- a/oauth2_provider/tests/models.py
+++ b/oauth2_provider/tests/models.py
@@ -1,8 +1,8 @@
 from django.db import models
-from oauth2_provider.models import (AbstractApplication,
-                                    AbstractGrant,
-                                    AbstractAccessToken,
-                                    AbstractRefreshToken)
+from oauth2_provider.compat import AUTH_USER_MODEL
+from oauth2_provider.models import (AbstractAccessToken, AbstractApplication,
+                                    AbstractGrant)
+from oauth2_provider.settings import oauth2_settings
 
 
 class TestApplication(AbstractApplication):
@@ -14,5 +14,19 @@ class TestGrant(AbstractGrant):
 class TestAccessToken(AbstractAccessToken):
     custom_field = models.CharField(max_length=255)
 
-class TestRefreshToken(AbstractRefreshToken):
-    custom_field = models.CharField(max_length=255)
+class TestRefreshToken(models.Model):
+    user = models.ForeignKey(AUTH_USER_MODEL)
+    token = models.CharField(max_length=255, db_index=True)
+    application = models.ForeignKey(oauth2_settings.APPLICATION_MODEL)
+    access_token = models.OneToOneField(oauth2_settings.ACCESS_TOKEN_MODEL,
+                                        related_name='test_refresh_token')
+
+    def revoke(self):
+        """
+        Delete this refresh token along with related access token
+        """
+        AccessToken.objects.get(id=self.access_token.id).revoke()
+        self.delete()
+
+    def __str__(self):
+        return self.token

--- a/oauth2_provider/tests/models.py
+++ b/oauth2_provider/tests/models.py
@@ -1,6 +1,18 @@
 from django.db import models
-from oauth2_provider.models import AbstractApplication
+from oauth2_provider.models import (AbstractApplication,
+                                    AbstractGrant,
+                                    AbstractAccessToken,
+                                    AbstractRefreshToken)
 
 
 class TestApplication(AbstractApplication):
+    custom_field = models.CharField(max_length=255)
+
+class TestGrant(AbstractGrant):
+    custom_field = models.CharField(max_length=255)
+
+class TestAccessToken(AbstractAccessToken):
+    custom_field = models.CharField(max_length=255)
+
+class TestRefreshToken(AbstractRefreshToken):
     custom_field = models.CharField(max_length=255)

--- a/oauth2_provider/tests/test_application_views.py
+++ b/oauth2_provider/tests/test_application_views.py
@@ -5,8 +5,8 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from ..models import get_application_model
 from ..compat import get_user_model
+from ..models import get_application_model
 
 Application = get_application_model()
 UserModel = get_user_model()

--- a/oauth2_provider/tests/test_auth_backends.py
+++ b/oauth2_provider/tests/test_auth_backends.py
@@ -1,18 +1,18 @@
-from django.test import TestCase, RequestFactory
-from django.test.utils import override_settings
-from django.contrib.auth.models import AnonymousUser
-from django.utils.timezone import now, timedelta
 from django.conf.global_settings import MIDDLEWARE_CLASSES
+from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from django.test.utils import override_settings
+from django.utils.timezone import now, timedelta
 
-from ..compat import get_user_model
-from ..models import get_application_model
-from ..models import AccessToken
 from ..backends import OAuth2Backend
+from ..compat import get_user_model
 from ..middleware import OAuth2TokenMiddleware
+from ..models import get_access_token_model, get_application_model
 
-UserModel = get_user_model()
 ApplicationModel = get_application_model()
+AccessToken = get_access_token_model()
+UserModel = get_user_model()
 
 
 class BaseTest(TestCase):

--- a/oauth2_provider/tests/test_authorization_code.py
+++ b/oauth2_provider/tests/test_authorization_code.py
@@ -1,24 +1,26 @@
 from __future__ import unicode_literals
 
 import base64
-import json
 import datetime
-import mock
+import json
 
-from django.test import TestCase, RequestFactory
+import mock
 from django.core.urlresolvers import reverse
+from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
 
-from ..compat import urlparse, parse_qs, urlencode, get_user_model
-from ..models import get_application_model, Grant, AccessToken, RefreshToken
+from ..compat import get_user_model, parse_qs, urlencode, urlparse
+from ..models import (get_access_token_model, get_application_model,
+                      get_grant_model, get_refersh_token_model)
 from ..settings import oauth2_settings
 from ..views import ProtectedResourceView
-
 from .test_utils import TestCaseUtils
 
-
 Application = get_application_model()
+Grant = get_grant_model()
+AccessToken = get_access_token_model()
+RefreshToken = get_refersh_token_model()
 UserModel = get_user_model()
 
 

--- a/oauth2_provider/tests/test_client_credential.py
+++ b/oauth2_provider/tests/test_client_credential.py
@@ -2,28 +2,27 @@ from __future__ import unicode_literals
 
 import json
 
-try:
-    import urllib.parse as urllib
-except ImportError:
-    import urllib
-
 from django.core.urlresolvers import reverse
-from django.test import TestCase, RequestFactory
+from django.test import RequestFactory, TestCase
 from django.views.generic import View
-
 from oauthlib.oauth2 import BackendApplicationServer
 
-from ..models import get_application_model, AccessToken
+from ..compat import get_user_model
+from ..models import get_access_token_model, get_application_model
 from ..oauth2_backends import OAuthLibCore
 from ..oauth2_validators import OAuth2Validator
 from ..settings import oauth2_settings
 from ..views import ProtectedResourceView
 from ..views.mixins import OAuthLibMixin
-from ..compat import get_user_model
 from .test_utils import TestCaseUtils
 
+try:
+    import urllib.parse as urllib
+except ImportError:
+    import urllib
 
 Application = get_application_model()
+AccessToken = get_access_token_model()
 UserModel = get_user_model()
 
 

--- a/oauth2_provider/tests/test_decorators.py
+++ b/oauth2_provider/tests/test_decorators.py
@@ -1,17 +1,17 @@
 import json
 from datetime import timedelta
 
-from django.test import TestCase, RequestFactory
+from django.test import RequestFactory, TestCase
 from django.utils import timezone
 
-from ..decorators import protected_resource, rw_protected_resource
-from ..settings import oauth2_settings
-from ..models import get_application_model, AccessToken
 from ..compat import get_user_model
+from ..decorators import protected_resource, rw_protected_resource
+from ..models import get_access_token_model, get_application_model
+from ..settings import oauth2_settings
 from .test_utils import TestCaseUtils
 
-
 Application = get_application_model()
+AccessToken = get_access_token_model()
 UserModel = get_user_model()
 
 

--- a/oauth2_provider/tests/test_generator.py
+++ b/oauth2_provider/tests/test_generator.py
@@ -2,9 +2,10 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
+from ..generators import (BaseHashGenerator, ClientIdGenerator,
+                          ClientSecretGenerator, generate_client_id,
+                          generate_client_secret)
 from ..settings import oauth2_settings
-from ..generators import (BaseHashGenerator, ClientIdGenerator, ClientSecretGenerator,
-                          generate_client_id, generate_client_secret)
 
 
 class MockHashGenerator(BaseHashGenerator):

--- a/oauth2_provider/tests/test_models.py
+++ b/oauth2_provider/tests/test_models.py
@@ -198,7 +198,7 @@ class TestAccessTokenModel(TestCase):
         self.assertTrue(access_token.is_expired())
 
 @skipIf(django.VERSION < (1, 5), "Behavior is broken on 1.4 and there is no solution")
-@override_settings(OAUTH2_PROVIDER_GRANT_MODEL='tests.TestAccessToken')
+@override_settings(OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL='tests.TestAccessToken')
 class TestCustomAccessTokenModel(TestCase):
     def setUp(self):
         self.user = UserModel.objects.create_user("test_user", "test@user.com", "123456")
@@ -226,7 +226,7 @@ class TestRefreshTokenModel(TestCase):
         self.assertEqual("%s" % refresh_token, refresh_token.token)
 
 @skipIf(django.VERSION < (1, 5), "Behavior is broken on 1.4 and there is no solution")
-@override_settings(OAUTH2_PROVIDER_GRANT_MODEL='tests.TestRefreshToken')
+@override_settings(OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL='tests.TestRefreshToken')
 class TestCustomRefreshTokenModel(TestCase):
     def setUp(self):
         self.user = UserModel.objects.create_user("test_user", "test@user.com", "123456")

--- a/oauth2_provider/tests/test_models.py
+++ b/oauth2_provider/tests/test_models.py
@@ -1,22 +1,27 @@
 from __future__ import unicode_literals
 
+import django
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import timezone
+
+from ..compat import get_user_model
+from ..models import (get_access_token_model, get_application_model,
+                      get_grant_model, get_refersh_token_model)
+
 try:
     from unittest import skipIf
 except ImportError:
     from django.utils.unittest.case import skipIf
 
-import django
-from django.test import TestCase
-from django.test.utils import override_settings
-from django.core.exceptions import ValidationError
-from django.utils import timezone
-
-from ..models import get_application_model, Grant, AccessToken, RefreshToken
-from ..compat import get_user_model
-
-
 Application = get_application_model()
+Grant = get_grant_model()
+AccessToken = get_access_token_model()
+RefreshToken = get_refersh_token_model()
 UserModel = get_user_model()
+
+APP_MODEL_SEPERATOR = ':' if django.VERSION < (1, 8) else '_'
 
 
 class TestModels(TestCase):
@@ -129,8 +134,9 @@ class TestCustomApplicationModel(TestCase):
         if django.VERSION < (1, 8):
             del UserModel._meta._related_objects_cache
         related_object_names = [ro.name for ro in UserModel._meta.get_all_related_objects()]
-        self.assertNotIn('oauth2_provider:application', related_object_names)
-        self.assertIn('tests%stestapplication' % (':' if django.VERSION < (1, 8) else '_'),
+        self.assertNotIn('oauth2_provider%sapplication' % APP_MODEL_SEPERATOR,
+                         related_object_names)
+        self.assertIn('tests%stestapplication' % APP_MODEL_SEPERATOR,
                       related_object_names)
 
 
@@ -145,6 +151,27 @@ class TestGrantModel(TestCase):
         self.assertIsNone(grant.expires)
         self.assertTrue(grant.is_expired())
 
+@skipIf(django.VERSION < (1, 5), "Behavior is broken on 1.4 and there is no solution")
+@override_settings(OAUTH2_PROVIDER_GRANT_MODEL='tests.TestGrant')
+class TestCustomGrantModel(TestCase):
+    def setUp(self):
+        self.user = UserModel.objects.create_user("test_user", "test@user.com", "123456")
+
+    def test_related_objects(self):
+        """
+        If a custom grant model is installed, it should be present in
+        the related objects and not the swapped out one.
+
+        See issue #90 (https://github.com/evonove/django-oauth-toolkit/issues/90)
+        """
+        # Django internals caches the related objects.
+        if django.VERSION < (1, 8):
+            del UserModel._meta._related_objects_cache
+        related_object_names = [ro.name for ro in UserModel._meta.get_all_related_objects()]
+        self.assertNotIn('oauth2_provider%sgrant' % APP_MODEL_SEPERATOR,
+                         related_object_names)
+        self.assertIn('tests%stestgrant' % APP_MODEL_SEPERATOR,
+                      related_object_names)
 
 class TestAccessTokenModel(TestCase):
     def setUp(self):
@@ -170,9 +197,52 @@ class TestAccessTokenModel(TestCase):
         self.assertIsNone(access_token.expires)
         self.assertTrue(access_token.is_expired())
 
+@skipIf(django.VERSION < (1, 5), "Behavior is broken on 1.4 and there is no solution")
+@override_settings(OAUTH2_PROVIDER_GRANT_MODEL='tests.TestAccessToken')
+class TestCustomAccessTokenModel(TestCase):
+    def setUp(self):
+        self.user = UserModel.objects.create_user("test_user", "test@user.com", "123456")
+
+    def test_related_objects(self):
+        """
+        If a custom access token model is installed, it should be present in
+        the related objects and not the swapped out one.
+
+        See issue #90 (https://github.com/evonove/django-oauth-toolkit/issues/90)
+        """
+        # Django internals caches the related objects.
+        if django.VERSION < (1, 8):
+            del UserModel._meta._related_objects_cache
+        related_object_names = [ro.name for ro in UserModel._meta.get_all_related_objects()]
+        self.assertNotIn('oauth2_provider%saccesstoken' % APP_MODEL_SEPERATOR,
+                         related_object_names)
+        self.assertIn('tests%stestaccesstoken' % APP_MODEL_SEPERATOR,
+                      related_object_names)
 
 class TestRefreshTokenModel(TestCase):
 
     def test_str(self):
         refresh_token = RefreshToken(token="test_token")
         self.assertEqual("%s" % refresh_token, refresh_token.token)
+
+@skipIf(django.VERSION < (1, 5), "Behavior is broken on 1.4 and there is no solution")
+@override_settings(OAUTH2_PROVIDER_GRANT_MODEL='tests.TestRefreshToken')
+class TestCustomRefreshTokenModel(TestCase):
+    def setUp(self):
+        self.user = UserModel.objects.create_user("test_user", "test@user.com", "123456")
+
+    def test_related_objects(self):
+        """
+        If a custom refresh token model is installed, it should be present in
+        the related objects and not the swapped out one.
+
+        See issue #90 (https://github.com/evonove/django-oauth-toolkit/issues/90)
+        """
+        # Django internals caches the related objects.
+        if django.VERSION < (1, 8):
+            del UserModel._meta._related_objects_cache
+        related_object_names = [ro.name for ro in UserModel._meta.get_all_related_objects()]
+        self.assertNotIn('oauth2_provider%srefreshtoken' % APP_MODEL_SEPERATOR,
+                         related_object_names)
+        self.assertIn('tests%stestrefreshtoken' % APP_MODEL_SEPERATOR,
+                      related_object_names)

--- a/oauth2_provider/tests/test_rest_framework.py
+++ b/oauth2_provider/tests/test_rest_framework.py
@@ -11,12 +11,13 @@ except ImportError:
     import unittest
 
 from .test_utils import TestCaseUtils
-from ..models import AccessToken, get_application_model
+from ..models import get_access_token_model, get_application_model
 from ..settings import oauth2_settings
 from ..compat import get_user_model
 
 
 Application = get_application_model()
+AccessToken = get_access_token_model()
 UserModel = get_user_model()
 
 

--- a/oauth2_provider/tests/test_scopes.py
+++ b/oauth2_provider/tests/test_scopes.py
@@ -8,11 +8,13 @@ from django.core.urlresolvers import reverse
 
 from .test_utils import TestCaseUtils
 from ..compat import urlparse, parse_qs, get_user_model, urlencode
-from ..models import get_application_model, Grant, AccessToken
+from ..models import get_application_model, get_grant_model, get_access_token_model
 from ..settings import oauth2_settings
 from ..views import ScopedProtectedResourceView, ReadWriteScopedResourceView
 
 Application = get_application_model()
+Grant = get_grant_model()
+AccessToken = get_access_token_model()
 UserModel = get_user_model()
 
 

--- a/oauth2_provider/tests/test_token_revocation.py
+++ b/oauth2_provider/tests/test_token_revocation.py
@@ -7,13 +7,15 @@ from django.core.urlresolvers import reverse
 from django.utils import timezone
 
 from ..compat import urlencode, get_user_model
-from ..models import get_application_model, AccessToken, RefreshToken
+from ..models import get_application_model, get_access_token_model, get_refersh_token_model
 from ..settings import oauth2_settings
 
 from .test_utils import TestCaseUtils
 
 
 Application = get_application_model()
+AccessToken = get_access_token_model()
+RefreshToken = get_refersh_token_model()
 UserModel = get_user_model()
 
 

--- a/oauth2_provider/tests/test_token_view.py
+++ b/oauth2_provider/tests/test_token_view.py
@@ -6,10 +6,11 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import timezone
 
-from ..models import get_application_model, AccessToken
+from ..models import get_application_model, get_access_token_model
 from ..compat import get_user_model
 
 Application = get_application_model()
+AccessToken = get_access_token_model()
 UserModel = get_user_model()
 
 


### PR DESCRIPTION
This is useful for having an access model token that encrypts the tokens in the database using pgcrypto fields or for replacing the user fields with denormalised user fields using [django-denorm](https://github.com/django-denorm/django-denorm).
There are a lot of other cases that require all models to be swappable. We can discuss them if you want.
Unfortunately I uncovered a regression in related fields of swappable models at least in Django 1.9 on Python 2.7.
We need to figure out why and fix it if possible.
