### PR TITLE
Add unique constraints to models' token codes

### DIFF
--- a/oauth2_provider/migrations/0004_auto_20160525_1623.py
+++ b/oauth2_provider/migrations/0004_auto_20160525_1623.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oauth2_provider', '0003_auto_20160316_1503'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='accesstoken',
+            name='token',
+            field=models.CharField(unique=True, max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='grant',
+            name='code',
+            field=models.CharField(unique=True, max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='refreshtoken',
+            name='token',
+            field=models.CharField(unique=True, max_length=255),
+        ),
+    ]

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -149,7 +149,7 @@ class Grant(models.Model):
     * :attr:`scope` Required scopes, optional
     """
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
-    code = models.CharField(max_length=255, db_index=True)  # code comes from oauthlib
+    code = models.CharField(max_length=255, unique=True)  # code comes from oauthlib
     application = models.ForeignKey(oauth2_settings.APPLICATION_MODEL)
     expires = models.DateTimeField()
     redirect_uri = models.CharField(max_length=255)
@@ -186,7 +186,7 @@ class AccessToken(models.Model):
     * :attr:`scope` Allowed scopes
     """
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
-    token = models.CharField(max_length=255, db_index=True)
+    token = models.CharField(max_length=255, unique=True)
     application = models.ForeignKey(oauth2_settings.APPLICATION_MODEL)
     expires = models.DateTimeField()
     scope = models.TextField(blank=True)
@@ -255,7 +255,7 @@ class RefreshToken(models.Model):
                            bounded to
     """
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
-    token = models.CharField(max_length=255, db_index=True)
+    token = models.CharField(max_length=255, unique=True)
     application = models.ForeignKey(oauth2_settings.APPLICATION_MODEL)
     access_token = models.OneToOneField(AccessToken,
                                         related_name='refresh_token')


### PR DESCRIPTION
For #382 

Add a unique constraint to the token codes to avoid `objects.get() MultipleObjectsReturned` exceptions.
