### PR TITLE
Reuse refresh tokens if enabled.

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -307,7 +307,7 @@ class OAuth2Validator(RequestValidator):
         """
 
         if 'scope' not in token:
-            raise FatalClientError(u"Failed to renew access token: missing scope")
+            raise FatalClientError("Failed to renew access token: missing scope")
 
         expires = timezone.now() + timedelta(seconds=oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS)
 


### PR DESCRIPTION
Reuse refresh tokens if it's enabled. This is based on a code sample
in #304 from https://github.com/evonove/django-oauth-toolkit/issues/304#issuecomment-175636716

For us, this has cleaned up a number of race conditions deleting and recreating
tokens.
