### PR TITLE
added an IsAuthenticatedOrTokenHasScope Permission

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Diego Garcia
 Bas van Oostveen
 Bart Merenda
 Paul Oswald
+Jens Timmerman

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,7 @@ Changelog
 Development
 ~~~~~~~~~~~
 
+* #396: added an IsAuthenticatedOrTokenHasScope Permission
 * #357: Support multiple-user clients by allowing User to be NULL for Applications
 
 0.10.0 [2015-12-14]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Development
 ~~~~~~~~~~~
 
+* #396: added an IsAuthenticatedOrTokenHasScope Permission
 * #357: Support multiple-user clients by allowing User to be NULL for Applications
 
 

--- a/docs/rest-framework/permissions.rst
+++ b/docs/rest-framework/permissions.rst
@@ -63,3 +63,21 @@ When the request's method is one of "non safe" methods, the access is allowed on
         required_scopes = ['music']
 
 The `required_scopes` attribute is mandatory (you just need inform the resource scope).
+
+
+IsAuthenticatedOrTokenHasScope
+------------------------------
+The `TokenHasResourceScope` permission class allows the access only when the current access token has been authorized for **all** the scopes listed in the `required_scopes` field of the view but according of request's method.
+And also allows access to Authenticated users who are authenticated in django, but were not authenticated trought the OAuth2Authentication class.
+This allows for protection of the api using scopes, but still let's users browse the full browseable API.
+To restrict users to only browse the parts of the browseable API they should be allowed to see, you can combine this wwith the DjangoModelPermission or the DjangoObjectPermission.
+
+For example:
+
+.. code-block:: python
+
+    class SongView(views.APIView):
+        permission_classes = [IsAuthenticatedOrTokenHasScope, DjangoModelPermission]
+        required_scopes = ['music']
+
+The `required_scopes` attribute is mandatory.

--- a/oauth2_provider/ext/rest_framework/__init__.py
+++ b/oauth2_provider/ext/rest_framework/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 from .authentication import OAuth2Authentication
 from .permissions import TokenHasScope, TokenHasReadWriteScope, TokenHasResourceScope
+from .permissions import IsAuthenticatedOrTokenHasScope

--- a/oauth2_provider/ext/rest_framework/permissions.py
+++ b/oauth2_provider/ext/rest_framework/permissions.py
@@ -3,6 +3,7 @@ import logging
 from django.core.exceptions import ImproperlyConfigured
 
 from rest_framework.permissions import BasePermission, IsAuthenticated
+from .authentication import OAuth2Authentication
 
 from ...settings import oauth2_settings
 
@@ -89,11 +90,18 @@ class TokenHasResourceScope(TokenHasScope):
 class IsAuthenticatedOrTokenHasScope(BasePermission):
     """
     The user is authenticated using some backend or the token has the right scope
+    This only returns True if the user is authenticated, but not using a token
+    or using a token, and the token has the correct scope.
+
     This is usefull when combined with the DjangoModelPermissions to allow people browse the browsable api's
     if they log in using the a non token bassed middleware,
     and let them access the api's using a rest client with a token
     """
     def has_permission(self, request, view):
-        is_authenticated = IsAuthenticated()
+        is_authenticated = IsAuthenticated().has_permission(request, view)
+        oauth2authenticated = False
+        if is_authenticated:
+            oauth2authenticated = isinstance(request.successful_authenticator, OAuth2Authentication)
+
         token_has_scope = TokenHasScope()
-        return is_authenticated.has_permission(request, view) or token_has_scope.has_permission(request, view)
+        return (is_authenticated and not oauth2authenticated) or token_has_scope.has_permission(request, view)

--- a/oauth2_provider/tests/test_rest_framework.py
+++ b/oauth2_provider/tests/test_rest_framework.py
@@ -19,7 +19,9 @@ UserModel = get_user_model()
 try:
     from rest_framework import permissions
     from rest_framework.views import APIView
+    from rest_framework.test import force_authenticate, APIRequestFactory
     from ..ext.rest_framework import OAuth2Authentication, TokenHasScope, TokenHasReadWriteScope, TokenHasResourceScope
+    from ..ext.rest_framework import IsAuthenticatedOrTokenHasScope
 
     class MockView(APIView):
         permission_classes = (permissions.IsAuthenticated,)
@@ -37,6 +39,10 @@ try:
         permission_classes = [permissions.IsAuthenticated, TokenHasScope]
         required_scopes = ['scope1']
 
+    class AuthenticatedOrScopedView(OAuth2View):
+        permission_classes = [IsAuthenticatedOrTokenHasScope]
+        required_scopes = ['scope1']
+
     class ReadWriteScopedView(OAuth2View):
         permission_classes = [permissions.IsAuthenticated, TokenHasReadWriteScope]
 
@@ -51,6 +57,7 @@ try:
         url(r'^oauth2-scoped-test/$', ScopedView.as_view()),
         url(r'^oauth2-read-write-test/$', ReadWriteScopedView.as_view()),
         url(r'^oauth2-resource-scoped-test/$', ResourceScopedView.as_view()),
+        url(r'^oauth2-authenticated-or-scoped-test/$', AuthenticatedOrScopedView.as_view()),
     )
 
     rest_framework_installed = True
@@ -106,12 +113,57 @@ class TestOAuth2Authentication(BaseTest):
         self.assertEqual(response.status_code, 401)
 
     @unittest.skipUnless(rest_framework_installed, 'djangorestframework not installed')
+    def test_authentication_or_scope_denied(self):
+        # user is not authenticated
+        # not a correct token
+        auth = self._create_authorization_header("fake-token")
+        response = self.client.get("/oauth2-authenticated-or-scoped-test/", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 401)
+        # token doesn't have correct scope
+        auth = self._create_authorization_header(self.access_token.token)
+
+        factory = APIRequestFactory()
+        request = factory.get("/oauth2-authenticated-or-scoped-test/")
+        request.auth = auth
+        force_authenticate(request, token=self.access_token)
+        response = AuthenticatedOrScopedView.as_view()(request)
+        # authenticated but wrong scope, this is 403, not 401
+        self.assertEqual(response.status_code, 403)
+
+    @unittest.skipUnless(rest_framework_installed, 'djangorestframework not installed')
     def test_scoped_permission_allow(self):
         self.access_token.scope = 'scope1'
         self.access_token.save()
 
         auth = self._create_authorization_header(self.access_token.token)
         response = self.client.get("/oauth2-scoped-test/", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 200)
+
+    @unittest.skipUnless(rest_framework_installed, 'djangorestframework not installed')
+    def test_authenticated_or_scoped_permission_allow(self):
+        self.access_token.scope = 'scope1'
+        self.access_token.save()
+        # correct token and correct scope
+        auth = self._create_authorization_header(self.access_token.token)
+        response = self.client.get("/oauth2-authenticated-or-scoped-test/", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 200)
+
+        auth = self._create_authorization_header("fake-token")
+        # incorrect token  but authenticated
+        factory = APIRequestFactory()
+        request = factory.get("/oauth2-authenticated-or-scoped-test/")
+        request.auth = auth
+        force_authenticate(request, self.test_user)
+        response = AuthenticatedOrScopedView.as_view()(request)
+        self.assertEqual(response.status_code, 200)
+
+        # correct token  but not authenticated
+        request = factory.get("/oauth2-authenticated-or-scoped-test/")
+        request.auth = auth
+        self.access_token.scope = 'scope1'
+        self.access_token.save()
+        force_authenticate(request, token=self.access_token)
+        response = AuthenticatedOrScopedView.as_view()(request)
         self.assertEqual(response.status_code, 200)
 
     @unittest.skipUnless(rest_framework_installed, 'djangorestframework not installed')


### PR DESCRIPTION
fixes #265 
based on code writen by  @werthen

we use this permission to allow people to browse and use the api, based on their model perimissions, and use the rest api based on the required scopes.
This means a user can browse everything he/she has permissions to browse, 
and an app with a token can get all the information the user has permissions to, as long as it's token has the correct scope (so the users granted the right permissions)
```
permission_classes = (IsAuthenticatedOrTokenHasScope, DjangoModelPermissions)
required_scopes = ['scope1']
```