### PR TITLE
Fix coverage since pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ python:
 sudo: false
 
 env:
-  - TOX_ENV=py27-django18
-  - TOX_ENV=py27-django19
-  - TOX_ENV=py32-django18
-  - TOX_ENV=py33-django18
-  - TOX_ENV=py34-django18
-  - TOX_ENV=py34-django19
-  - TOX_ENV=py35-django18
-  - TOX_ENV=py35-django19
-  - TOX_ENV=docs
+  - TOXENV=py27-django18
+  - TOXENV=py27-django19
+  - TOXENV=py32-django18
+  - TOXENV=py33-django18
+  - TOXENV=py34-django18
+  - TOXENV=py34-django19
+  - TOXENV=py35-django18
+  - TOXENV=py35-django19
+  - TOXENV=docs
 
 matrix:
   fast_finish: true
@@ -23,7 +23,7 @@ install:
   - pip install coveralls
 
 script:
-  - tox -e $TOX_ENV
+  - tox
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ install:
 script:
   - tox
 
-after_success:
+after_script:
   - coveralls

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,4 +3,3 @@ mock==1.0.1
 pytest==2.8.3
 pytest-django==2.9.1
 pytest-xdist==1.13.1
-pytest-cov==2.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,15 @@ commands=python runtests.py -q --cov oauth2_provider --cov-report= --cov-append
 deps =
     django18: Django==1.8.11
     django19: Django==1.9.4
-    coverage<4
+    coverage==4.1
+    pytest-cov==2.3.0
+    -rrequirements/testing.txt
+
+[testenv:py32-django18]
+# coverage-4.1 doesn't support python-3.2.
+commands=python runtests.py -q
+deps =
+    django18: Django==1.8.11
     -rrequirements/testing.txt
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,16 @@ testpaths=oauth2_provider
 
 [tox]
 envlist =
-    {py27}-django{18,19},
-    {py32}-django{18},
-    {py33}-django{18},
-    {py34}-django{18,19},
-    {py35}-django{18,19},
+    py27-django{18,19},
+    py32-django18,
+    py33-django18,
+    py34-django{18,19},
+    py35-django{18,19},
     docs,
     flake8
 
 [testenv]
-commands=python runtests.py -q --cov oauth2_provider --cov-report= --cov-append
+commands=python runtests.py -q --cov=oauth2_provider --cov-report= --cov-append
 deps =
     django18: Django==1.8.11
     django19: Django==1.9.4


### PR DESCRIPTION
Coverage measurement has been broken since updating to pytest. See https://coveralls.io/repos/3350/builds?page=7 and https://travis-ci.org/evonove/django-oauth-toolkit/jobs/141547004, or the following screenshots

![screenshot from 2016-07-10 12-57-43](https://cloud.githubusercontent.com/assets/50637/16714861/13f7861a-469e-11e6-8fc1-a5f7dcb7ebc0.png)

![screenshot from 2016-07-10 12-58-12](https://cloud.githubusercontent.com/assets/50637/16714862/190e1628-469e-11e6-828d-368c5528ba1e.png)

It's not completely clear WHY coverage broke, but it's simple to fix by updating to the latest pytest-cov and coverage.py
