### PR TITLE
Properly handle race condition when refresh token already revoked

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -302,7 +302,8 @@ class OAuth2Validator(RequestValidator):
             try:
                 RefreshToken.objects.get(token=request.refresh_token).revoke()
             except RefreshToken.DoesNotExist:
-                assert()  # TODO though being here would be very strange, at least log the error
+                # other client already revoked it.
+                pass
 
         expires = timezone.now() + timedelta(seconds=oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS)
         if request.grant_type == 'client_credentials':


### PR DESCRIPTION
Thank you for this project, it's working really well!

We have this traceback popping up in production from time to time:

```
Stacktrace (most recent call last):
  File "django/core/handlers/base.py", line 149, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "django/utils/decorators.py", line 67, in _wrapper
    return bound_func(*args, **kwargs)
  File "django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "django/utils/decorators.py", line 63, in bound_func
    return func.__get__(self, type(self))(*args2, **kwargs2)
  File "braces/views/_forms.py", line 22, in dispatch
    return super(CsrfExemptMixin, self).dispatch(*args, **kwargs)
  File "django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "django/utils/decorators.py", line 67, in _wrapper
    return bound_func(*args, **kwargs)
  File "django/views/decorators/debug.py", line 76, in sensitive_post_parameters_wrapper
    return view(request, *args, **kwargs)
  File "django/utils/decorators.py", line 63, in bound_func
    return func.__get__(self, type(self))(*args2, **kwargs2)
  File "oauth2_provider/views/base.py", line 170, in post
    url, headers, body, status = self.create_token_response(request)
  File "oauth2_provider/views/mixins.py", line 124, in create_token_response
    return core.create_token_response(request)
  File "oauth2_provider/oauth2_backends.py", line 138, in create_token_response
    headers, extra_credentials)
  File "oauthlib/oauth2/rfc6749/endpoints/base.py", line 64, in wrapper
    return f(endpoint, uri, *args, **kwargs)
  File "oauthlib/oauth2/rfc6749/endpoints/token.py", line 100, in create_token_response
    request, self.default_token_type)
  File "oauthlib/oauth2/rfc6749/grant_types/refresh_token.py", line 63, in create_token_response
    refresh_token=self.issue_new_refresh_tokens)
  File "oauthlib/oauth2/rfc6749/tokens.py", line 276, in create_token
    self.request_validator.save_bearer_token(token, request)
  File "oauth2_provider/oauth2_validators.py", line 304, in save_bearer_token
    assert()  # TODO though being here would be very strange, at least log the error
```

To me it seems like this condition simply happens when another client already revoked the token, and that this shouldn't be an error.  I could be missing some context so please advise if there is more to it.
