### PR TITLE
Suggest django-cors-middleware

### DIFF
--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -9,14 +9,14 @@ Start Your App
 --------------
 During this tutorial you will make an XHR POST from a Heroku deployed app to your localhost instance.
 Since the domain that will originate the request (the app on Heroku) is different from the destination domain (your local instance),
-you will need to install the `django-cors-headers <https://github.com/ottoyiu/django-cors-headers>`_ app.
+you will need to install the `django-cors-middleware <https://github.com/zestedesavoir/django-cors-middleware>`_ app.
 These "cross-domain" requests are by default forbidden by web browsers unless you use `CORS <http://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_.
 
-Create a virtualenv and install `django-oauth-toolkit` and `django-cors-headers`:
+Create a virtualenv and install `django-oauth-toolkit` and `django-cors-middleware`:
 
 ::
 
-    pip install django-oauth-toolkit django-cors-headers
+    pip install django-oauth-toolkit django-cors-middleware
 
 Start a Django project, add `oauth2_provider` and `corsheaders` to the installed apps, and enable admin:
 


### PR DESCRIPTION
Since `django-cors-headers` has been inactive since May 2015, the documentation should suggest using `django-cors-middleware`. This is a fork of `django-cors-headers` that has been kept up to date, so it supports Django 1.10.