### PR TITLE
Use the OAuthLibCore object defined at the module level.

### DIFF
--- a/oauth2_provider/backends.py
+++ b/oauth2_provider/backends.py
@@ -15,8 +15,7 @@ class OAuth2Backend(object):
     def authenticate(self, **credentials):
         request = credentials.get('request')
         if request is not None:
-            oauthlib_core = get_oauthlib_core()
-            valid, r = oauthlib_core.verify_request(request, scopes=[])
+            valid, r = OAuthLibCore.verify_request(request, scopes=[])
             if valid:
                 return r.user
         return None


### PR DESCRIPTION
An OAuthLibCore object is already defined at the module level. Use that, instead of calling `get_oauthlib_core` again in the `authenticate` method.