### PR TITLE
Minor improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,11 @@ Roadmap / Todo list (help wanted)
 Changelog
 ---------
 
+0.12.0 [Unreleased]
+~~~~~~~~~~
+
+* Support for the `scopes` query parameter, deprecated in 0.6.1, has been dropped
+
 0.11.0 [2016-12-1]
 ~~~~~~~~~~~
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -32,6 +32,14 @@ The number of seconds an access token remains valid. Requesting a protected
 resource after this duration will fail. Keep this value high enough so clients
 can cache the token for a reasonable amount of time.
 
+ALLOWED_REDIRECT_URI_SCHEMES
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``["http", "https"]``
+
+A list of schemes that the ``redirect_uri`` field will be validated against.
+Setting this to ``["https"]`` only in production is strongly recommended.
+
 APPLICATION_MODEL
 ~~~~~~~~~~~~~~~~~
 The import string of the class (model) representing your applications. Overwrite

--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -3,13 +3,34 @@ from django.contrib import admin
 from .models import Grant, AccessToken, RefreshToken, get_application_model
 
 
-class RawIDAdmin(admin.ModelAdmin):
-    raw_id_fields = ('user',)
+class ApplicationAdmin(admin.ModelAdmin):
+    list_display = ("name", "user", "client_type", "authorization_grant_type")
+    list_filter = ("client_type", "authorization_grant_type", "skip_authorization")
+    radio_fields = {
+        "client_type": admin.HORIZONTAL,
+        "authorization_grant_type": admin.VERTICAL,
+    }
+    raw_id_fields = ("user", )
+
+
+class GrantAdmin(admin.ModelAdmin):
+    list_display = ("code", "application", "user", "expires")
+    raw_id_fields = ("user", )
+
+
+class AccessTokenAdmin(admin.ModelAdmin):
+    list_display = ("token", "user", "application", "expires")
+    raw_id_fields = ("user", )
+
+
+class RefreshTokenAdmin(admin.ModelAdmin):
+    list_display = ("token", "user", "application", "expires")
+    raw_id_fields = ("user", "access_token")
 
 
 Application = get_application_model()
 
-admin.site.register(Application, RawIDAdmin)
-admin.site.register(Grant, RawIDAdmin)
-admin.site.register(AccessToken, RawIDAdmin)
-admin.site.register(RefreshToken, RawIDAdmin)
+admin.site.register(Application, ApplicationAdmin)
+admin.site.register(Grant, GrantAdmin)
+admin.site.register(AccessToken, AccessTokenAdmin)
+admin.site.register(RefreshToken, RefreshTokenAdmin)

--- a/oauth2_provider/compat_handlers.py
+++ b/oauth2_provider/compat_handlers.py
@@ -1,6 +1,0 @@
-# flake8: noqa
-# Django 1.9 drops the NullHandler since Python 2.7 includes it
-try:
-    from logging import NullHandler
-except ImportError:
-    from django.utils.log import NullHandler

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -8,10 +8,3 @@ class AllowForm(forms.Form):
     client_id = forms.CharField(widget=forms.HiddenInput())
     state = forms.CharField(required=False, widget=forms.HiddenInput())
     response_type = forms.CharField(widget=forms.HiddenInput())
-
-    def __init__(self, *args, **kwargs):
-        data = kwargs.get('data')
-        # backwards compatible support for plural `scopes` query parameter
-        if data and 'scopes' in data:
-            data['scope'] = data['scopes']
-        return super(AllowForm, self).__init__(*args, **kwargs)

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -17,15 +17,12 @@ back to the defaults.
 """
 from __future__ import unicode_literals
 
+import importlib
 import six
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-try:
-    # Available in Python 2.7+
-    import importlib
-except ImportError:
-    from django.utils import importlib
+
 
 USER_SETTINGS = getattr(settings, 'OAUTH2_PROVIDER', None)
 

--- a/oauth2_provider/tests/settings.py
+++ b/oauth2_provider/tests/settings.py
@@ -108,7 +108,7 @@ LOGGING = {
         },
         'null': {
             'level': 'DEBUG',
-            'class': 'oauth2_provider.compat_handlers.NullHandler',
+            'class': 'logging.NullHandler',
         },
     },
     'loggers': {

--- a/oauth2_provider/urls.py
+++ b/oauth2_provider/urls.py
@@ -3,23 +3,26 @@ from django.conf.urls import url
 
 from . import views
 
-urlpatterns = [
+
+base_urlpatterns = [
     url(r'^authorize/$', views.AuthorizationView.as_view(), name="authorize"),
     url(r'^token/$', views.TokenView.as_view(), name="token"),
     url(r'^revoke_token/$', views.RevokeTokenView.as_view(), name="revoke-token"),
 ]
 
-# Application management views
-urlpatterns += [
+
+management_urlpatterns = [
+    # Application management views
     url(r'^applications/$', views.ApplicationList.as_view(), name="list"),
     url(r'^applications/register/$', views.ApplicationRegistration.as_view(), name="register"),
     url(r'^applications/(?P<pk>\d+)/$', views.ApplicationDetail.as_view(), name="detail"),
     url(r'^applications/(?P<pk>\d+)/delete/$', views.ApplicationDelete.as_view(), name="delete"),
     url(r'^applications/(?P<pk>\d+)/update/$', views.ApplicationUpdate.as_view(), name="update"),
-]
-
-urlpatterns += [
+    # Token management views
     url(r'^authorized_tokens/$', views.AuthorizedTokensListView.as_view(), name="authorized-token-list"),
     url(r'^authorized_tokens/(?P<pk>\d+)/delete/$', views.AuthorizedTokenDeleteView.as_view(),
         name="authorized-token-delete"),
 ]
+
+
+urlpatterns = base_urlpatterns + management_urlpatterns


### PR DESCRIPTION
This PR drops old Python 2.6 compatibility shims, adds better administration for the builtin models (including a crucial fix adding `access_token` to `raw_id_fields`) and splits the base and management views in `urls.py` so that either can be accessed and included separately - without breaking backwards compatibility.