### PR TITLE
Removed skip-authorization

### DIFF
--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -24,7 +24,7 @@ class AccessTokenAdmin(admin.ModelAdmin):
 
 
 class RefreshTokenAdmin(admin.ModelAdmin):
-    list_display = ("token", "user", "application", "expires")
+    list_display = ("token", "user", "application")
     raw_id_fields = ("user", "access_token")
 
 

--- a/oauth2_provider/tests/test_scopes.py
+++ b/oauth2_provider/tests/test_scopes.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase, RequestFactory
 
 from .test_utils import TestCaseUtils
-from ..compat import urlparse, parse_qs, urlencode
+from ..compat import urlparse, parse_qs
 from ..models import get_application_model, Grant, AccessToken
 from ..settings import oauth2_settings
 from ..views import ScopedProtectedResourceView, ReadWriteScopedResourceView

--- a/oauth2_provider/views/application.py
+++ b/oauth2_provider/views/application.py
@@ -69,3 +69,13 @@ class ApplicationUpdate(ApplicationOwnerIsUserMixin, UpdateView):
     """
     context_object_name = 'application'
     template_name = "oauth2_provider/application_form.html"
+
+    def get_form_class(self):
+        """
+        Returns the form class for the application model
+        """
+        return modelform_factory(
+            get_application_model(),
+            fields=('name', 'client_id', 'client_secret', 'client_type',
+                    'authorization_grant_type', 'redirect_uris')
+        )


### PR DESCRIPTION
This pr adds on `ApplicationUpdate` view the following method:

```python
def get_form_class(self):
```

Removed field `expires` from `RefreshTokenAdmin`

Removed unused import from tests