### PR TITLE
Add app_name to urls.py

### DIFF
--- a/oauth2_provider/urls.py
+++ b/oauth2_provider/urls.py
@@ -4,6 +4,9 @@ from django.conf.urls import url
 from . import views
 
 
+app_name = 'oauth2_provider'
+
+
 base_urlpatterns = [
     url(r'^authorize/$', views.AuthorizationView.as_view(), name="authorize"),
     url(r'^token/$', views.TokenView.as_view(), name="token"),


### PR DESCRIPTION
Fixes this warning in Django 1.10:
```
RemovedInDjango20Warning: Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated. Set the app_name attribute in the included module, or pass a 2-tuple containing the list of patterns and app_name instead.
  url([...], include('oauth2_provider.urls', namespace='oauth2_provider')),
```

Also, when you want to drop support for Django 1.8, it won't be necessary with this change to declare `namespace` explicitly.