### PR TITLE
Customizable application grant type

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -125,6 +125,9 @@ class AbstractApplication(models.Model):
     def __str__(self):
         return self.name or self.client_id
 
+    def allows_grant_type(self, *grant_types):
+        return self.authorization_grant_type in grant_types
+
 
 class Application(AbstractApplication):
     class Meta(AbstractApplication.Meta):

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -263,7 +263,7 @@ class OAuth2Validator(RequestValidator):
         Validate both grant_type is a valid string and grant_type is allowed for current workflow
         """
         assert(grant_type in GRANT_TYPE_MAPPING)  # mapping misconfiguration
-        return request.client.authorization_grant_type in GRANT_TYPE_MAPPING[grant_type]
+        return request.client.allows_grant_type(*GRANT_TYPE_MAPPING[grant_type])
 
     def validate_response_type(self, client_id, response_type, client, request, *args, **kwargs):
         """
@@ -271,9 +271,9 @@ class OAuth2Validator(RequestValidator):
         rfc:`8.4`, so validate the response_type only if it matches 'code' or 'token'
         """
         if response_type == 'code':
-            return client.authorization_grant_type == AbstractApplication.GRANT_AUTHORIZATION_CODE
+            return client.allows_grant_type(AbstractApplication.GRANT_AUTHORIZATION_CODE)
         elif response_type == 'token':
-            return client.authorization_grant_type == AbstractApplication.GRANT_IMPLICIT
+            return client.allows_grant_type(AbstractApplication.GRANT_IMPLICIT)
         else:
             return False
 

--- a/oauth2_provider/tests/test_oauth2_backends.py
+++ b/oauth2_provider/tests/test_oauth2_backends.py
@@ -13,7 +13,7 @@ class TestOAuthLibCoreBackend(TestCase):
         self.factory = RequestFactory()
         self.oauthlib_core = OAuthLibCore()
 
-    def test_swappable_serer_class(self):
+    def test_swappable_server_class(self):
         with mock.patch('oauth2_provider.oauth2_backends.oauth2_settings.OAUTH2_SERVER_CLASS'):
             oauthlib_core = OAuthLibCore()
             self.assertTrue(isinstance(oauthlib_core.server, mock.MagicMock))


### PR DESCRIPTION
Hello,

Using DOT in my app, I wanted to customize my Application model to support multiple (not combined) grant flows. If I understand correctly, this is @skrivanos's request on #69 .

This PR implements a new api method on AbstractApplication  to check if the instance allows a grant type and just a few modifications on the validator so that it doesn't make assumptions on Application.authorization_grant_type and asks the application model instead.

This is transparent for the existing tests and does not decrease coverage as far as I can tell.
It doesn't seem to contradict the RFC as it doesn't forbid multiple grant flows to be allowed for one client : 
[RFC 6749 section 1.2](https://tools.ietf.org/html/rfc6749#section-1.2)
> The client receives an authorization grant, which is a
> credential representing the resource owner's authorization,
> expressed using one of four grant types defined in this
> specification or using an extension grant type.  The
> authorization grant type depends on the method used by the
> client to request authorization and the types supported by the
> authorization server.


However, it may break existing custom Application models by introducing a new requirement on its API, so the PR probably needs more love to avoid this breakage.

Can someone please review and comment ?
