### PR TITLE
added missing imports in doc: Tutorial Part 2

### DIFF
--- a/docs/tutorial/tutorial_02.rst
+++ b/docs/tutorial/tutorial_02.rst
@@ -34,7 +34,7 @@ URL this view will respond to:
 
 .. code-block:: python
 
-    from django.conf.urls import url
+    from django.conf.urls import url, include
     import oauth2_provider.views as oauth2_views
     from django.conf import settings
     from .views import ApiEndpoint


### PR DESCRIPTION
The code sample in tutorial part 2 is not working properly by simple copy-and-paste because  `include` has been removed from the default `urls.py` template since https://github.com/django/django/commit/1e82094f1b6690018228e688303295f83e1c3d9a