### PR TITLE
Disallow empty redirect URIs

### DIFF
--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -61,5 +61,8 @@ def validate_uris(value):
     This validator ensures that `value` contains valid blank-separated URIs"
     """
     v = RedirectURIValidator(oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES)
-    for uri in value.split():
+    uris = value.split()
+    if not uris:
+        raise ValidationError('Redirect URI cannot be empty')
+    for uri in uris:
         v(uri)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -34,3 +34,7 @@ class TestValidators(TestCase):
         self.assertRaises(ValidationError, validate_uris, bad_uri)
         bad_uri = 'sdklfsjlfjljdflksjlkfjsdkl'
         self.assertRaises(ValidationError, validate_uris, bad_uri)
+        bad_uri = '     '
+        self.assertRaises(ValidationError, validate_uris, bad_uri)
+        bad_uri = ''
+        self.assertRaises(ValidationError, validate_uris, bad_uri)


### PR DESCRIPTION
The empty string does no longer pass the URI validator. This does not
make existing code that relies on `blank=True' fail, it just fixes the
case where the user provides an empty string.

Signed-off-by: Rigas Papathanasopoulos <rigas@arrikto.com>