### PR TITLE
Add signals when a token is generated

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Index
    views/details
    models
    advanced_topics
+   signals
    settings
    resource_server
    management_commands

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -1,0 +1,24 @@
+Signals
+=======
+
+Django-oauth-toolkit sends messages to various signals, depending on the action
+that has been triggered.
+
+You can easily import signals from `oauth2_provider.signals` and attach your
+own listeners.
+
+For example:
+
+.. code-block:: python
+
+    from oauth2_provider.signals import app_authorized
+
+    def handle_app_authorized(sender, request, application, **kwargs):
+        print('App {} was authorized'.format(application.name))
+
+    app_authorized.connect(handle_app_authorized)
+
+Currently supported signals are:
+
+* `oauth2_provider.signals.app_authorized` - fired once an oauth code has been
+  authorized and an access token has been granted

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -13,8 +13,8 @@ For example:
 
     from oauth2_provider.signals import app_authorized
 
-    def handle_app_authorized(sender, request, application, **kwargs):
-        print('App {} was authorized'.format(application.name))
+    def handle_app_authorized(sender, request, token, **kwargs):
+        print('App {} was authorized'.format(token.application.name))
 
     app_authorized.connect(handle_app_authorized)
 

--- a/oauth2_provider/signals.py
+++ b/oauth2_provider/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+app_authorized = Signal(providing_args=['request', 'application'])

--- a/oauth2_provider/signals.py
+++ b/oauth2_provider/signals.py
@@ -1,3 +1,3 @@
 from django.dispatch import Signal
 
-app_authorized = Signal(providing_args=['request', 'application'])
+app_authorized = Signal(providing_args=['request', 'token'])

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -192,7 +192,7 @@ class TokenView(OAuthLibMixin, View):
                     token=access_token)
                 app_authorized.send(
                     sender=self, request=request,
-                    application=token.application)
+                    token=token)
         response = HttpResponse(content=body, status=status)
 
         for k, v in headers.items():

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -14,7 +14,7 @@ from .mixins import OAuthLibMixin
 from ..exceptions import OAuthToolkitError
 from ..forms import AllowForm
 from ..http import HttpResponseUriRedirect
-from ..models import get_access_token_model, get_application_model, AccessToken
+from ..models import get_access_token_model, get_application_model
 from ..scopes import get_scopes_backend
 from ..settings import oauth2_settings
 
@@ -188,7 +188,8 @@ class TokenView(OAuthLibMixin, View):
         if status == 200:
             access_token = json.loads(body).get('access_token')
             if access_token is not None:
-                token = AccessToken.objects.get(token=access_token)
+                token = get_access_token_model().objects.get(
+                    token=access_token)
                 app_authorized.send(
                     sender=self, request=request,
                     application=token.application)


### PR DESCRIPTION
This PR adds a very simple signal that fires up each time a token has been generated for an application.

Now I don't know if this is the right place to have such signal, but it looks like the right one (oauthlib isn't django-specific, so it didn't seem a good place to put it there in `create_token_response`).

Please let me know if it's a feature that you'd like to see in the upstream - if so, I will write additional unit tests.