### PR TITLE
Parse URI only once in AbstractApplication.redirect_uri_allowed.

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -108,16 +108,16 @@ class AbstractApplication(models.Model):
 
         :param uri: Url to check
         """
+        parsed_uri = urlparse(uri)
+        uqs_set = set(parse_qsl(parsed_uri.query))
         for allowed_uri in self.redirect_uris.split():
             parsed_allowed_uri = urlparse(allowed_uri)
-            parsed_uri = urlparse(uri)
 
             if (parsed_allowed_uri.scheme == parsed_uri.scheme and
                     parsed_allowed_uri.netloc == parsed_uri.netloc and
                     parsed_allowed_uri.path == parsed_uri.path):
 
                 aqs_set = set(parse_qsl(parsed_allowed_uri.query))
-                uqs_set = set(parse_qsl(parsed_uri.query))
 
                 if aqs_set.issubset(uqs_set):
                     return True


### PR DESCRIPTION
Just a minor inconvenience but it seems unnecessary to me to parse the same
parameter value multiple times in case there are more than one permitted redirect
URIs.