### PR TITLE
Fix RefreshToken model setting name

### DIFF
--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -28,7 +28,7 @@ USER_SETTINGS = getattr(settings, "OAUTH2_PROVIDER", None)
 APPLICATION_MODEL = getattr(settings, "OAUTH2_PROVIDER_APPLICATION_MODEL", "oauth2_provider.Application")
 ACCESS_TOKEN_MODEL = getattr(settings, "OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL", "oauth2_provider.AccessToken")
 GRANT_MODEL = getattr(settings, "OAUTH2_PROVIDER_GRANT_MODEL", "oauth2_provider.Grant")
-REFRESH_TOKEN_MODEL = getattr(settings, "OAUTH2_PROVIDER_REFRESH_MODEL", "oauth2_provider.RefreshToken")
+REFRESH_TOKEN_MODEL = getattr(settings, "OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL", "oauth2_provider.RefreshToken")
 
 DEFAULTS = {
     "CLIENT_ID_GENERATOR_CLASS": "oauth2_provider.generators.ClientIdGenerator",


### PR DESCRIPTION
The settings class used `OAUTH2_PROVIDER_REFRESH_MODEL` as the setting name, while most of the code used `OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL` (which makes more sense as well), leading to conflicts.