### PR TITLE
Pass request to Django's auth.authenticate function

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -514,7 +514,7 @@ class OAuth2Validator(RequestValidator):
         """
         Check username and password correspond to a valid and active User
         """
-        u = authenticate(username=username, password=password)
+        u = authenticate(request=request, username=username, password=password)
         if u is not None and u.is_active:
             request.user = u
             return True


### PR DESCRIPTION
Since Django 1.11 the request parameter was added and it is now passed to authentication backends.

https://docs.djangoproject.com/en/1.11/topics/auth/default/#django.contrib.auth.authenticate