### PR TITLE
Remove dependencies to models that create circular errors

### DIFF
--- a/oauth2_provider/migrations/0001_initial.py
+++ b/oauth2_provider/migrations/0001_initial.py
@@ -11,11 +11,7 @@ from django.conf import settings
 class Migration(migrations.Migration):
 
     dependencies = [
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        migrations.swappable_dependency(oauth2_settings.APPLICATION_MODEL),
-        migrations.swappable_dependency(oauth2_settings.ACCESS_TOKEN_MODEL),
-        migrations.swappable_dependency(oauth2_settings.REFRESH_TOKEN_MODEL),
-        migrations.swappable_dependency(oauth2_settings.GRANT_MODEL),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL)
     ]
 
     operations = [


### PR DESCRIPTION
This should fix circular migrations error like those in #525 
The changes in this PR are supported by 2 things:
 - tried to remove manually the dependencies that were creating circular migratiosn dependency error which worked
 - tried to rebuild django-oauth-toolkit migrations from scratch obtaining this result
![migrations](https://user-images.githubusercontent.com/4163222/33550039-d11bde58-d8ec-11e7-8775-ed752dfdbcc8.png)


Now I'm not an expert of swappable models and I don't get them totally but this solutions seems to me the right one not only because django creates the migration with only one dependency to the `user` model but because If anybody tries to subclass one of the models, I don't see how the migrations for the subclassed model can work since:
 - sublcassed model migrations depend on `django-oauth-toolkit 0001`
 - `django-oauth-toolkit` migration 0001 depends on `subclassed 0001`

Happy to take this discussion further @jleclanche 
/CC @menecio @synasius pinging you too since I noticed you added those additional dependencies