### PR TITLE
Add a requirements.txt file in docs for builds to succeed

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+Django==1.11.5
+django-oauth-toolkit==1.0.0


### PR DESCRIPTION
The reason the docs have not been build is that when the read the docs tries to build it fails with django and oauth2_provider ImportError (in docs/conf.py). Solution was to add a requirements file with at least django and django-oauth-toolkit so that RTD installs it during its build process.
 
This was probably introduced when the project switched to using tox for dependancy installation.

This solution has been tested here http://django-oauth-toolkit-latest.readthedocs.io/en/latest/index.html

closes #506