### PR TITLE
Delete Refresh token before Access Token to avoid cascade deadlock

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -335,8 +335,10 @@ class AbstractRefreshToken(models.Model):
         Delete this refresh token along with related access token
         """
         access_token_model = get_access_token_model()
-        access_token_model.objects.get(id=self.access_token.id).revoke()
+        token = access_token_model.objects.get(id=self.access_token.id)
+        # Avoid cascade by deleting self first.
         self.delete()
+        token.revoke()
 
     def __str__(self):
         return self.token


### PR DESCRIPTION
Fix for difficult to reproduce issue of #514. 
It is a concurrency issue which I fail to reproduce in a docker/controlled environment.
This change was done for Python 3.4
In absence of reproduction capabilities we deployed this change to our production servers.
The issue hasn't come up since.

