### PR TITLE
Expire AccessTokens even when REFRESH_TOKEN_EXPIRE_SECONDS is not set

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -389,5 +389,5 @@ def clear_expired():
     with transaction.atomic():
         if refresh_expire_at:
             refresh_token_model.objects.filter(access_token__expires__lt=refresh_expire_at).delete()
-            access_token_model.objects.filter(refresh_token__isnull=True, expires__lt=now).delete()
+        access_token_model.objects.filter(refresh_token__isnull=True, expires__lt=now).delete()
         grant_model.objects.filter(expires__lt=now).delete()


### PR DESCRIPTION
If refresh tokens are not being used or if REFRESH_TOKEN_EXPIRE_SECONDS is not set in the settings then access tokens are never cleaned up by the `cleartokens` command.

This used to be the behaviour, but it looks like there was an un-intended indentation change in https://github.com/evonove/django-oauth-toolkit/commit/be8bcccc0adce86862c9d35ae50afc42a3a28d95