### PR TITLE
Don't require write scope for introspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ pip-log.txt
 .cache
 .coverage
 .tox
+.pytest_cache/
 nosetests.xml
 
 # Translations

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -9,11 +9,11 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
 from oauth2_provider.models import get_access_token_model
-from oauth2_provider.views import ReadWriteScopedResourceView
+from oauth2_provider.views import ScopedProtectedResourceView
 
 
 @method_decorator(csrf_exempt, name="dispatch")
-class IntrospectTokenView(ReadWriteScopedResourceView):
+class IntrospectTokenView(ScopedProtectedResourceView):
     """
     Implements an endpoint for token introspection based
     on RFC 7662 https://tools.ietf.org/html/rfc7662

--- a/tests/test_introspection_auth.py
+++ b/tests/test_introspection_auth.py
@@ -96,7 +96,7 @@ class TestTokenIntrospectionAuth(TestCase):
             user=self.resource_server_user, token="12345678900",
             application=self.application,
             expires=timezone.now() + datetime.timedelta(days=1),
-            scope="read write introspection"
+            scope="introspection"
         )
 
         self.invalid_token = AccessToken.objects.create(

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -38,7 +38,7 @@ class TestTokenIntrospectionViews(TestCase):
             user=self.resource_server_user, token="12345678900",
             application=self.application,
             expires=timezone.now() + datetime.timedelta(days=1),
-            scope="read write introspection"
+            scope="introspection"
         )
 
         self.valid_token = AccessToken.objects.create(


### PR DESCRIPTION
Replacing `ReadWriteScopedResourceView` with `ScopedProtectedResourceView`

fixes #555